### PR TITLE
Rolled back to gradle-2.0-bin.zip. Don't know why it changed to -all.zip

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip


### PR DESCRIPTION
This is just the rollback to `-bin.zip` from `-all.zip`
