### PR TITLE
FIxes #53

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testJRubyPrepare 'org.jruby:jruby-complete:1.7.14'
 }
 
+
 repositories {
     jcenter()
     mavenLocal()

--- a/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
+++ b/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
@@ -1,11 +1,7 @@
 package com.github.jrubygradle
 
-import org.gradle.api.file.FileCollection
 import org.gradle.testfixtures.ProjectBuilder
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
-import spock.lang.IgnoreRest
-import spock.lang.Specification
+import spock.lang.*
 
 import static org.gradle.api.logging.LogLevel.LIFECYCLE
 

--- a/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
+++ b/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
@@ -132,6 +132,7 @@ class JRubyExec extends JavaExec {
             configuration = JRUBYEXEC_CONFIG
         }
 
+        GemUtils.OverwriteAction overwrite = project.gradle.startParameter.refreshDependencies ?  GemUtils.OverwriteAction.OVERWRITE : GemUtils.OverwriteAction.SKIP
         def jrubyCompletePath = project.configurations.getByName(jrubyConfigurationName)
         File gemDir = tmpGemDir()
         gemDir.mkdirs()
@@ -143,7 +144,7 @@ class JRubyExec extends JavaExec {
                     jrubyCompletePath,
                     project.configurations.getByName(configuration),
                     gemDir,
-                    GemUtils.OverwriteAction.OVERWRITE
+                    overwrite
             )
         }
 

--- a/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
+++ b/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
@@ -120,8 +120,9 @@ class JRubyExecDelegate {
         proxy.validate()
         File gemDir=new File(project.jruby.gemInstallDir)
         Configuration config = project.configurations.getByName(JRUBYEXEC_CONFIG)
+        GemUtils.OverwriteAction overwrite = project.gradle.startParameter.refreshDependencies ?  GemUtils.OverwriteAction.OVERWRITE : GemUtils.OverwriteAction.SKIP
         project.mkdir gemDir
-        GemUtils.extractGems(project,config,config,gemDir,GemUtils.OverwriteAction.SKIP)
+        GemUtils.extractGems(project,config,config,gemDir,overwrite)
 
         project.javaexec {
             classpath JRubyExecUtils.classpathFromConfiguration(config)


### PR DESCRIPTION
`JRubyExec` will now only overwrite local GEMs if `--refresh-dependencies` is specified on the command-line.  This improves the speeds of writing `JRubyExec` instances where a large number of gems are required.
