### PR TITLE
Make the JRubyExec `script` argument optional provided `jrubyArgs` is present

### DIFF
--- a/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
+++ b/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
@@ -38,7 +38,6 @@ class JRubyExec extends JavaExec {
     /** Script to execute.
      *
      */
-    @InputFile
     File script
 
     /** Configuration to copy gems from. If {@code jRubyVersion} has not been set, {@code jRubyExec} will used as
@@ -158,8 +157,15 @@ class JRubyExec extends JavaExec {
     @Override
     List<String> getArgs() {
         def cmdArgs = []
+
+        if ((script == null) && (jrubyArgs.size() == 0)) {
+            throw new TaskInstantiationException('Cannot instantiate a JRubyExec instance without either `script` or `jrubyArgs` set')
+        }
         cmdArgs.addAll(jrubyArgs)
-        cmdArgs.add(script.absolutePath)
+
+        if (script != null) {
+            cmdArgs.add(script.absolutePath)
+        }
         cmdArgs.addAll(scriptArgs)
         cmdArgs as List<String>
     }

--- a/src/test/groovy/com/github/jrubygradle/JRubyExecSpec.groovy
+++ b/src/test/groovy/com/github/jrubygradle/JRubyExecSpec.groovy
@@ -143,4 +143,24 @@ class JRubyExecSpec extends Specification {
             execTask.getArgs() == ['-j1','-j2','-j3',new File(TEST_SCRIPT_DIR,'helloWorld.rb').absolutePath,'-s1','-s2','-s3']
     }
 
+    def "Properly handle the lack of a `script` argument"() {
+        when:
+            project.configure(execTask) {
+                jrubyArgs '-S', 'rspec'
+            }
+
+        then:
+            execTask.getArgs() == ['-S', 'rspec']
+    }
+
+    def "Error when `script` is empty and there is no `jrubyArgs`"() {
+        when:
+            project.configure(execTask) {
+            }
+            execTask.getArgs()
+
+        then: "An exception should be thrown"
+            thrown(TaskInstantiationException)
+    }
+
 }


### PR DESCRIPTION
Fixes #62
