### PR TITLE
generate .jrubydir files for installed gems

### DIFF
--- a/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
+++ b/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
@@ -44,6 +44,7 @@ class JRubyPrepareGemsIntegrationSpec extends Specification {
 
         expect:
             new File(jrpg.outputDir,"gems/slim-${SLIM_VERSION}").exists()
+            new File(jrpg.outputDir,"specifications/.jrubydir").exists()
     }
 
 //    @IgnoreIf({TESTS_ARE_OFFLINE})

--- a/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
+++ b/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
@@ -112,6 +112,11 @@ class GemUtils {
 
                 systemProperties 'file.encoding' : 'utf-8'
             }
+            project.javaexec {
+                main 'org.jruby.Main'
+                classpath jRubyClasspath
+                args '-r', 'jruby/commands', '-e', "JRuby::Commands.generate_dir_info( '${destDir.absolutePath}' )"
+            }
         }
     }
 


### PR DESCRIPTION
this is the first towards using jruby-mains but valid as such since it allows to create jar files with embedded gems (used by org.jruby.ScriptingContainer or javax.scripting) on all environments (OSGi, J2EE, etc) - for jruby-1.7.x you need to add ```uri:classloader://``` to LOAD_PATH - on jruby-9k it is already default.