### PR TITLE
 Resolved issues port #108 merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    testCompile 'junit:junit:4.+'
-
-    String spockVersion = "org.spockframework:spock-core:0.7-groovy-${gradle.gradleVersion.startsWith('1.')?'1.8':'2.0'}"
+    String spockVersion = "org.spockframework:spock-core:1.0-groovy-2.3"
 
     testCompile (spockVersion) {
         exclude module : 'groovy-all'

--- a/src/main/groovy/com/github/jrubygradle/internal/JRubyExecUtils.groovy
+++ b/src/main/groovy/com/github/jrubygradle/internal/JRubyExecUtils.groovy
@@ -42,9 +42,30 @@ class JRubyExecUtils {
      * @since 0.1.9
      */
     @CompileDynamic
-    static String jrubyJarVersion(File jar) {
+    static String jrubyJarVersion(final File jar) {
         Matcher matches = jar.name =~ /jruby-complete-(.+)\.jar/
         !matches ? null : matches[0][1]
+    }
+
+    /** Extracts the JRuby version number as a triplet from a jruby-complete-XXX.jar filename
+     *
+     * @param jar JRuby Jar
+     * @return Version string map [major,minor,patchlevel] or null
+     *
+     * @since 0.1.16
+     */
+    @CompileDynamic
+    static Map jrubyJarVersionTriple(final File jar) {
+        String version = jrubyJarVersion(jar)
+        if(!version) {return null}
+
+        Matcher matches = version =~ /(\d{1,2})\.(\d{1,3})\.(\d{1,3})/
+
+        (!matches.matches() || matches[0].size() != 4) ? null : [
+            major : matches[0][1].toInteger(),
+            minor : matches[0][2].toInteger(),
+            patchlevel : matches[0][3].toInteger()
+        ]
     }
 
     /** Extract the jruby-complete-XXX.jar as a FileCollection

--- a/src/test/groovy/com/github/jrubygradle/internal/JRubyExecUtilsSpec.groovy
+++ b/src/test/groovy/com/github/jrubygradle/internal/JRubyExecUtilsSpec.groovy
@@ -26,4 +26,28 @@ class JRubyExecUtilsSpec extends Specification {
         cmdArgs instanceof List<String>
         cmdArgs.find { it == 'spock' }
     }
+
+    def "The version string in a jruby jar filename must be extracted correctly"() {
+
+        expect:
+            version == JRubyExecUtils.jrubyJarVersion(new File(jarName))
+
+        where:
+            jarName || version
+            'jruby-complete-1.7.14.jar' || '1.7.14'
+            'jruby-complete-22.999.888.jar' || '22.999.888'
+            'jruby-complete.jar' || null
+    }
+
+    def "The version information in a jruby jar filename must be extracted correctly"() {
+
+        expect:
+           triplet == JRubyExecUtils.jrubyJarVersionTriple(new File(jarName))
+
+        where:
+            jarName || triplet
+            'jruby-complete-1.7.14.jar'     || [ major : 1, minor : 7, patchlevel : 14]
+            'jruby-complete-22.999.888.jar' || [ major : 22, minor : 999, patchlevel : 888 ]
+            'jruby-complete.jar'            || null
+    }
 }


### PR DESCRIPTION
- Fixed an issue with creating .jrubydir entries for jruby < 1.7.19. Solution is to not create them for now and log a warning. 
- Upgraded Spock to 1.0