### PR TITLE
fixes two problems with the GemVersion

### DIFF
--- a/src/main/groovy/com/github/jrubygradle/internal/GemVersion.groovy
+++ b/src/main/groovy/com/github/jrubygradle/internal/GemVersion.groovy
@@ -72,6 +72,9 @@ class GemVersion {
             postfix = version.charAt( version.size() - 1 ).toString()
             low = FIRST.matcher(TAIL.matcher(version).replaceFirst('')).replaceFirst('')
             high = LAST.matcher(HEAD.matcher(version).replaceFirst('')).replaceFirst('')
+            if (high == '' ){
+              high = '99999'
+            }
         }
         else {
             low = version
@@ -155,7 +158,7 @@ class GemVersion {
                 return 0
             }
             else {
-                return -1
+                return 1
             }
         }
         def aaObject

--- a/src/test/groovy/com/github/jrubygradle/internal/GemVersionSpec.groovy
+++ b/src/test/groovy/com/github/jrubygradle/internal/GemVersionSpec.groovy
@@ -27,6 +27,14 @@ class GemVersionSpec extends Specification {
         subject.toString() == '[1.2.0,1.2.99999]'
     }
 
+    def "parses maven open version range"() {
+        given:
+        GemVersion subject = new GemVersion('[1.2,)')
+
+        expect:
+        subject.toString() == '[1.2,99999)'
+    }
+
     def "parses maven version range first sample"() {
         given:
         GemVersion subject = new GemVersion('(1.2.0, 1.2.4)')
@@ -121,6 +129,22 @@ class GemVersionSpec extends Specification {
 
         expect:
         subject.intersect('[1.2.2, 1.3]').toString() == '[1.2.2,1.2.14]'
+    }
+
+    def "intersects two versions special one"() {
+        given:
+        GemVersion subject = new GemVersion('[0.9.0,0.9.99999]')
+
+        expect:
+        subject.intersect('[0,)').toString() == '[0.9.0,0.9.99999]'
+    }
+
+    def "intersects two versions special one"() {
+        given:
+        GemVersion subject = new GemVersion('[0,)')
+
+        expect:
+        subject.intersect('[0.9.0,0.9.99999]').toString() == '[0.9.0,0.9.99999]'
     }
 
     def "intersects with conflict"() {


### PR DESCRIPTION
* maven open ranges [1.2,) will be converted to [1.2,99999) to allow numerical comparison
* the intersection of [0,) and [4.0, 4.5] worked only in one direction