### PR TITLE
use jruby-mains-0.4.0

### DIFF
--- a/jruby-gradle-jar-plugin/build.gradle
+++ b/jruby-gradle-jar-plugin/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testRepo ("org.jruby:jruby-complete:${jrubyVersion}") {
         transitive = false
     }
-    testRepo ('de.saumya.mojo:jruby-mains:0.3.1') {
+    testRepo ('org.jruby.mains:jruby-mains:0.4.0') {
         transitive = false
     }
     testRepo ("org.spockframework:spock-core:0.7-groovy-2.0") {

--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
@@ -21,8 +21,8 @@ class JRubyJar extends Jar {
     enum Type { RUNNABLE, LIBRARY }
 
     static final String DEFAULT_JRUBYJAR_CONFIG = 'jrubyJar'
-    static final String DEFAULT_MAIN_CLASS = 'de.saumya.mojo.mains.JarMain'
-    static final String EXTRACTING_MAIN_CLASS = 'de.saumya.mojo.mains.ExtractingMain'
+    static final String DEFAULT_MAIN_CLASS = 'org.jruby.mains.JarMain'
+    static final String EXTRACTING_MAIN_CLASS = 'org.jruby.mains.ExtractingMain'
 
     protected String jrubyVersion
 
@@ -40,7 +40,7 @@ class JRubyJar extends Jar {
     }
 
     @Input
-    String jrubyMainsVersion = '0.3.1'
+    String jrubyMainsVersion = '0.4.0'
 
     void jrubyMainsVersion(String version) {
         this.jrubyMainsVersion = version
@@ -186,7 +186,7 @@ class JRubyJar extends Jar {
 
     void addJRubyDependencies(Configuration config) {
         project.dependencies.add(config.name, "org.jruby:jruby-complete:${getJrubyVersion()}")
-        project.dependencies.add(config.name, "de.saumya.mojo:jruby-mains:${getJrubyMainsVersion()}")
+        project.dependencies.add(config.name, "org.jruby.mains:jruby-mains:${getJrubyMainsVersion()}")
     }
 
     void updateDependencies() {


### PR DESCRIPTION
jruby-mains moved to the jruby organization, i.e. it has a different
maven coordinate as well different java package names