### PR TITLE
remove trailing 0 version parts on ranges

### DIFF
--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/GemVersion.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/GemVersion.groovy
@@ -42,6 +42,7 @@ class GemVersion {
     private static Pattern TAIL = Pattern.compile(',.*$')
     private static Pattern FIRST = Pattern.compile('^[\\[\\(]')
     private static Pattern LAST = Pattern.compile('[\\]\\)]$')
+    private static Pattern ZEROS = Pattern.compile('(\\.0)+$')
 
     private String low
     private String high
@@ -63,14 +64,14 @@ class GemVersion {
      */
     GemVersion(String version) {
         if (version.contains( '+' ) ) {
-            low = PLUS.matcher(DOT_PLUS.matcher(version).replaceFirst('.0')).replaceFirst('')
+            low = ZEROS.matcher(PLUS.matcher(DOT_PLUS.matcher(version).replaceFirst('.0')).replaceFirst('')).replaceFirst('')
             high = DIGITS_PLUS.matcher(DOT_PLUS.matcher(version).replaceFirst('.99999')).replaceFirst('99999')
         }
-        else if (version.contains( LOW_IN ) || version.contains( UP_EX ) ||
+        else if (version.contains( LOW_IN ) || version.contains( LOW_EX ) ||
                  version.contains( UP_IN ) || version.contains( UP_EX ) ) {
             prefix = version.charAt( 0 ).toString()
             postfix = version.charAt( version.size() - 1 ).toString()
-            low = FIRST.matcher(TAIL.matcher(version).replaceFirst('')).replaceFirst('')
+            low = ZEROS.matcher(FIRST.matcher(TAIL.matcher(version).replaceFirst('')).replaceFirst('')).replaceFirst('')
             high = LAST.matcher(HEAD.matcher(version).replaceFirst('')).replaceFirst('')
             if (high == '' ){
               high = '99999'

--- a/jruby-gradle-base-plugin/src/test/groovy/com/github/jrubygradle/internal/GemVersionSpec.groovy
+++ b/jruby-gradle-base-plugin/src/test/groovy/com/github/jrubygradle/internal/GemVersionSpec.groovy
@@ -32,12 +32,12 @@ class GemVersionSpec extends Specification {
         GemVersion subject = new GemVersion('1.2.+')
 
         expect:
-        subject.toString() == '[1.2.0,1.2.99999]'
+        subject.toString() == '[1.2,1.2.99999]'
     }
 
     def "parses maven open version range"() {
         given:
-        GemVersion subject = new GemVersion('[1.2,)')
+        GemVersion subject = new GemVersion('[1.2.0,)')
 
         expect:
         subject.toString() == '[1.2,99999)'
@@ -45,10 +45,10 @@ class GemVersionSpec extends Specification {
 
     def "parses maven version range first sample"() {
         given:
-        GemVersion subject = new GemVersion('(1.2.0, 1.2.4)')
+        GemVersion subject = new GemVersion('(1.2.0.0, 1.2.4)')
 
         expect:
-        subject.toString() == '(1.2.0,1.2.4)'
+        subject.toString() == '(1.2,1.2.4)'
     }
 
     def "parses maven version range second sample"() {
@@ -56,7 +56,7 @@ class GemVersionSpec extends Specification {
         GemVersion subject = new GemVersion('(1.2.0, 1.2.4]')
 
         expect:
-        subject.toString() == '(1.2.0,1.2.4]'
+        subject.toString() == '(1.2,1.2.4]'
     }
 
     def "parses maven version range third sample"() {
@@ -64,23 +64,39 @@ class GemVersionSpec extends Specification {
         GemVersion subject = new GemVersion('[1.2.0, 1.2.4)')
 
         expect:
-        subject.toString() == '[1.2.0,1.2.4)'
+        subject.toString() == '[1.2,1.2.4)'
     }
 
     def "parses maven version range forth sample"() {
         given:
-        GemVersion subject = new GemVersion('[1.2.0, 1.2.4]')
+        GemVersion subject = new GemVersion('[1.2.1, 1.2.4]')
 
         expect:
-        subject.toString() == '[1.2.0,1.2.4]'
+        subject.toString() == '[1.2.1,1.2.4]'
+    }
+
+    def "parses maven version range trailing zeros"() {
+        given:
+        GemVersion subject = new GemVersion('[1.2.1.0.0.0, 1.2.4]')
+
+        expect:
+        subject.toString() == '[1.2.1,1.2.4]'
+    }
+
+    def "parses maven version range trailing zeros as prereleased version"() {
+        given:
+        GemVersion subject = new GemVersion('[1.2.1.0.pre.0, 1.2.4]')
+
+        expect:
+        subject.toString() == '[1.2.1.0.pre,1.2.4]'
     }
 
     def "intersects two versions first sample"() {
         given:
-        GemVersion subject = new GemVersion('[1.2.0, 1.2.4]')
+        GemVersion subject = new GemVersion('[1.2.1, 1.2.4]')
 
         expect:
-        subject.intersect('(1.2.0, 1.2.4)').toString() == '(1.2.0,1.2.4)'
+        subject.intersect('(1.2.1, 1.2.4)').toString() == '(1.2.1,1.2.4)'
     }
 
     def "intersects two versions second sample"() {
@@ -104,7 +120,7 @@ class GemVersionSpec extends Specification {
         GemVersion subject = new GemVersion('(1.2.0, 1.2.4)')
 
         expect:
-        subject.intersect('[1.2.0, 1.2.4]').toString() == '(1.2.0,1.2.4)'
+        subject.intersect('[1.2.0, 1.2.4]').toString() == '(1.2,1.2.4)'
     }
 
     def "intersects two versions second sample reversed"() {
@@ -144,7 +160,7 @@ class GemVersionSpec extends Specification {
         GemVersion subject = new GemVersion('[0.9.0,0.9.99999]')
 
         expect:
-        subject.intersect('[0,)').toString() == '[0.9.0,0.9.99999]'
+        subject.intersect('[0,)').toString() == '[0.9,0.9.99999]'
     }
 
     def "intersects two versions special one"() {
@@ -152,7 +168,7 @@ class GemVersionSpec extends Specification {
         GemVersion subject = new GemVersion('[0,)')
 
         expect:
-        subject.intersect('[0.9.0,0.9.99999]').toString() == '[0.9.0,0.9.99999]'
+        subject.intersect('[0.9.0,0.9.99999]').toString() == '[0.9,0.9.99999]'
     }
 
     def "intersects with conflict"() {


### PR DESCRIPTION
gradle can not resolve 1.0.4.0 to 1.0.4 the same way maven does. removing the tailing
'0' helps to be more in line with maven.

fixes #213