### PR TITLE
Restrict gradleTest to 2.0, 2.2 and 2.6

### DIFF
--- a/jruby-gradle-base-plugin/build.gradle
+++ b/jruby-gradle-base-plugin/build.gradle
@@ -148,7 +148,7 @@ gradleLocations {
 }
 
 gradleTest {
-    versions '2.0','2.2','2.4'
+    versions '2.0','2.2','2.6'
     dependsOn jar
 }
 // vim: ft=groovy

--- a/jruby-gradle-jar-plugin/gradle/integration-test.gradle
+++ b/jruby-gradle-jar-plugin/gradle/integration-test.gradle
@@ -53,7 +53,7 @@ task integrationTest(type: Test) {
 check.dependsOn integrationTest
 
 gradleTest {
-    versions '2.0', '2.2', '2.4', '2.6'
+    versions '2.0', '2.2', '2.6'
     dependsOn test, integrationTest, jar
 }
 


### PR DESCRIPTION
IMO 2.4 is no longer worth testing specifically for