### PR TITLE
Prevent new instantiations of JRubyDirInfo from deleting the dirinfo

### DIFF
--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfo.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfo.groovy
@@ -15,7 +15,6 @@ class JRubyDirInfo {
 
     JRubyDirInfo(File dir) {
         dirInfo = dir
-        dirInfo.deleteDir();
     }
 
     File toFile(File path, String subdir) {


### PR DESCRIPTION
This will allow the dirinfo directory to be used as a staging ground but as
@mkristian correctly points out, this means the dirinfo directory will get more
and more stale/inaccurate as time goes on. This necessitates a refactored
approach to generating the .jrubydir files and injecting them into the packed
jar file

Fixes #220