### PR TITLE
make sure the generated Jars.lock file matches the installed jars

### DIFF
--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
@@ -155,22 +155,20 @@ class GemUtils {
         extractGems(project,jRubyClasspath,project.files(gemConfig.files),destDir,action)
     }
 
-    static void writeJarsLock(File jarsLock, List<String> coordinates,
-                              GemUtils.OverwriteAction overwrite) {
-        switch(overwrite) {
-            case OverwriteAction.FAIL:
-                if (jarsLock.exists()) {
-                    throw new DuplicateFileCopyingException("${jarsLock.name} already exists")
-                }
-            case OverwriteAction.SKIP:
-                if (jarsLock.exists()) {
-                    break
-                }
-            case OverwriteAction.OVERWRITE:
-                jarsLock.parentFile.mkdirs()
-                jarsLock.withWriter { writer ->
-                    coordinates.each { writer.println it }
-                }
+    static void writeJarsLock(File jarsLock, List<String> coordinates) {
+        // just write out the file when it changed or none-existing
+        String content;
+        if (jarsLock.exists()) {
+            content = jarsLock.text
+        }
+        else {
+            jarsLock.parentFile.mkdirs()
+            content = ''
+        }
+        StringWriter newContent = new StringWriter()
+        coordinates.each { newContent.println it }
+        if (content != newContent.toString()) {
+            jarsLock.text = newContent
         }
     }
 
@@ -224,7 +222,7 @@ class GemUtils {
         }
 
         // create Jars.lock file used by jar-dependencies
-        writeJarsLock(new File(destDir, 'Jars.lock'), coordinates, overwrite)
+        writeJarsLock(new File(destDir, 'Jars.lock'), coordinates)
 
         rewriteJarDependencies(new File(destDir, 'jars'), files, fileRenameMap, overwrite)
     }

--- a/jruby-gradle-base-plugin/src/test/groovy/com/github/jrubygradle/GemUtilsSpec.groovy
+++ b/jruby-gradle-base-plugin/src/test/groovy/com/github/jrubygradle/GemUtilsSpec.groovy
@@ -122,46 +122,34 @@ class GemUtilsSpec extends Specification {
 
     def "write Jars.lock"() {
         when:
-            GemUtils.OverwriteAction.values().each {
-                File jarsLock = new File(dest, "jars-${it}.lock")
-                jarsLock.delete()
-                GemUtils.writeJarsLock(jarsLock, [ 'something' ], it)
-            }
+            File jarsLock = new File(dest, "jars.lock")
+            jarsLock.delete()
+            GemUtils.writeJarsLock(jarsLock, [ 'something' ])
 
         then:
-            new File(dest, "jars-FAIL.lock").text =~ /something/
-            new File(dest, "jars-SKIP.lock").text =~ /something/
-            new File(dest, "jars-OVERWRITE.lock").text =~ /something/
+            jarsLock.text =~ /something/
     }
 
     def "skip write Jars.lock"() {
         when:
             File jarsLock = new File(dest, "jars.lock")
-            jarsLock << ''
-            GemUtils.writeJarsLock(jarsLock, [ 'something' ], GemUtils.OverwriteAction.SKIP)
+            jarsLock << 'something' << System.getProperty("line.separator")
+            jarsLock.setLastModified(0)
+            GemUtils.writeJarsLock(jarsLock, [ 'something' ])
 
         then:
-            new File(dest, "jars.lock").length() == 0
+            jarsLock.text =~ /something/
+            jarsLock.lastModified() == 0
     }
 
     def "overwrite write Jars.lock"() {
         when:
             File jarsLock = new File(dest, "jars.lock")
             jarsLock << ''
-            GemUtils.writeJarsLock(jarsLock, [ 'something' ], GemUtils.OverwriteAction.OVERWRITE)
+            GemUtils.writeJarsLock(jarsLock, [ 'something' ])
 
         then:
             new File(dest, "jars.lock").text =~ /something/
-    }
-
-    def "fail write Jars.lock"() {
-        when:
-            File jarsLock = new File(dest, "jars.lock")
-            jarsLock << ''
-            GemUtils.writeJarsLock(jarsLock, [ 'something' ], GemUtils.OverwriteAction.FAIL)
-
-        then:
-            thrown(DuplicateFileCopyingException)
     }
 
     def "rewrite jar dependency"() {


### PR DESCRIPTION
instead using an Overwrite strategy either create the file if it is not
there or compare the old content with new content and write out the
file if something changed.

fixes #229