### PR TITLE
Candidate fixes for 1.1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 group = 'com.github.jruby-gradle'
-version = '1.1.3'
+version = '1.1.4'
 defaultTasks 'check', 'assemble'
 
 if (!releaseBuild) {

--- a/examples/self-executing-jar/build.gradle
+++ b/examples/self-executing-jar/build.gradle
@@ -7,6 +7,11 @@ buildscript {
     repositories { jcenter() }
 
     dependencies {
+        /* here to make sure that our dependencies get loaded in properly under
+         * GradleTest, this is NOT needed by end-users
+         */
+        classpath 'com.github.jengelman.gradle.plugins:shadow:[1.2.2,2.0)'
+
         /* Replace "%%VERSION%%" with the version of JRuby/Gradle you wish to
          * use if you want to use this build.gradle outside of gradleTest
          */

--- a/jruby-gradle-base-plugin/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
+++ b/jruby-gradle-base-plugin/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
@@ -42,9 +42,8 @@ class JRubyPrepareGemsIntegrationSpec extends Specification {
 
         expect:
             new File(jrpg.outputDir,"gems/slim-${SLIM_VERSION}").exists()
-            new File(jrpg.outputDir,"specifications/.jrubydir").exists()
     }
-  
+
     def "Check if rack version gets resolved"() {
         given:
             def root= new File(TESTROOT, "rack-resolve")
@@ -65,7 +64,7 @@ class JRubyPrepareGemsIntegrationSpec extends Specification {
             // resolved version here can vary over time
             new File(jrpg.outputDir,"gems/rack-1.5.5").exists()
     }
-  
+
     def "Check if prerelease gem gets resolved"() {
         given:
             def root= new File(TESTROOT, "prerelease")

--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
@@ -120,17 +120,6 @@ class GemUtils {
 
                 systemProperties 'file.encoding' : 'utf-8'
             }
-
-            if(jrubyVersion.major == 1 && jrubyVersion.minor <= 7 && jrubyVersion.patchlevel < 19) {
-                project.logger.warn "Not generating JRuby directory info information as current JRuby version < 1.7.19"
-            } else {
-                project.javaexec {
-                    main 'org.jruby.Main'
-                    classpath jRubyClasspath
-                    args '-r', 'jruby/commands', '-e', "JRuby::Commands.generate_dir_info( '${destDir.absolutePath}' )"
-
-                }
-            }
         }
     }
 

--- a/jruby-gradle-jar-plugin/build.gradle
+++ b/jruby-gradle-jar-plugin/build.gradle
@@ -11,6 +11,7 @@ configurations {
 
 dependencies {
     compile project(':jruby-gradle-base-plugin')
+    compile 'com.github.jengelman.gradle.plugins:shadow:[1.2.2,2.0)'
 
     testCompile ("org.spockframework:spock-core:0.7-groovy-${gradle.gradleVersion.startsWith('1.')?'1.8':'2.0'}") {
         exclude module : 'groovy-all'

--- a/jruby-gradle-jar-plugin/gradle/integration-test.gradle
+++ b/jruby-gradle-jar-plugin/gradle/integration-test.gradle
@@ -74,6 +74,7 @@ dependencies {
     integrationTestRuntime files(prepareGradleTestKitClasspath)
 
     gradleTest project(':jruby-gradle-base-plugin')
+    gradleTest 'com.github.jengelman.gradle.plugins:shadow:[1.2.2,2.0)'
 
     testJRubyPrepare "org.jruby:jruby-complete:1.7.19"
 }

--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
@@ -1,20 +1,30 @@
 package com.github.jrubygradle.jar
 
 import com.github.jrubygradle.JRubyPrepare
-import com.github.jrubygradle.jar.internal.JRubyDirInfo
+import com.github.jrubygradle.jar.internal.JRubyDirInfoTransformer
+import com.github.jrubygradle.jar.internal.JRubyJarCopyAction
 import groovy.transform.PackageScope
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.Task
-import org.gradle.api.execution.TaskExecutionListener
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskState
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.bundling.ZipEntryCompression
 import org.gradle.api.tasks.StopExecutionException
+import org.gradle.api.internal.file.copy.CopyAction
+
+import org.apache.tools.zip.ZipOutputStream
+import com.github.jengelman.gradle.plugins.shadow.internal.ZipCompressor
+import com.github.jengelman.gradle.plugins.shadow.internal.DefaultZipCompressor
 
 /**
+ * JRubyJar creates a Java ARchive with Ruby code packed inside of it.
+ *
+ * The most common use-case is when packing a self-contained executable jar
+ * which would contain your application code, the JRuby runtime and a launcher
+ * library to set up the runtime when the jar is executed.
+ *
  * @author Christian Meier
  */
 class JRubyJar extends Jar {
@@ -222,7 +232,6 @@ class JRubyJar extends Jar {
     /** Update the staging directory and tasks responsible for setting it up */
     void updateStageDirectory() {
         File dir = project.file("${project.buildDir}/dirinfo/${configuration}")
-        dirInfo = new JRubyDirInfo(dir)
 
         prepareTask.dependencies project.configurations.maybeCreate(configuration)
         prepareTask.outputDir dir
@@ -231,24 +240,35 @@ class JRubyJar extends Jar {
         from(dir) {
             include 'specifications/**', 'gems/**', 'jars/**', 'bin/**', 'Jars.lock'
         }
+    }
 
-        project.gradle.taskGraph.addTaskExecutionListener(
-            new TaskExecutionListener() {
-                void afterExecute(Task task, TaskState state) {
-                    /* no op */
-                    return
-                }
+    /**
+     * Provide a custom {@link CopyAction} to insert .jrubydir files into the archive.
+     *
+     * This is currently relying on lots of shadow plugin internals, be very
+     * careful modifying this function :)
+     *
+     * @return instance of a CopyAction to perform the copy into the archive
+     */
+    @Override
+    protected CopyAction createCopyAction() {
+        return new JRubyJarCopyAction(getArchivePath(),
+                                    getInternalCompressor(),
+                                    null, /* DocumentationRegistry */
+                                    [new JRubyDirInfoTransformer()], /* transformers */
+                                    [], /* relocators */
+                                    mainSpec.buildRootResolver().getPatternSet())
+    }
 
-                void beforeExecute(Task task) {
-                    if (task.name == this.name) {
-                        task.getSource().visit {
-                            dirInfo.add(it.relativePath)
-                        }
-                    }
-                }
+    protected ZipCompressor getInternalCompressor() {
+        switch (entryCompression) {
+            case ZipEntryCompression.DEFLATED:
+                return new DefaultZipCompressor(this.zip64, ZipOutputStream.DEFLATED);
+            case ZipEntryCompression.STORED:
+                return new DefaultZipCompressor(this.zip64, ZipOutputStream.STORED);
+            default:
+                throw new IllegalArgumentException(String.format("Unknown Compression type %s", entryCompression));
             }
-        )
-
     }
 
     /**
@@ -264,7 +284,6 @@ class JRubyJar extends Jar {
     }
 
     protected Object scriptName
-    protected JRubyDirInfo dirInfo
     protected JRubyPrepare prepareTask
     protected String customConfigName
     protected String embeddedJRubyVersion

--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfoTransformer.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfoTransformer.groovy
@@ -1,0 +1,101 @@
+package com.github.jrubygradle.jar.internal
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import org.apache.tools.zip.ZipOutputStream
+import org.apache.tools.zip.ZipEntry
+import org.codehaus.plexus.util.IOUtil
+import org.gradle.api.file.FileTreeElement
+
+import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
+import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+
+/**
+ * JRubyDirInfoTransformer implements a {@link Transformer} interface.
+ *
+ * This is internal primarily because it rewrequires an interaction with the
+ * transformer interface inside of the shadow plugin, which will hopefully go
+ * away at some point in the future
+ */
+class JRubyDirInfoTransformer implements Transformer {
+    protected File tmpDir
+    protected JRubyDirInfo info
+
+    JRubyDirInfoTransformer() {
+        tmpDir = Files.createTempDirectory('jrubydirinfo').toFile()
+        info = new JRubyDirInfo(tmpDir)
+    }
+
+    /**
+     * Register the relative path of the {@code element} that will be jarred.
+     *
+     * Since this transformer is just performing book-keeping, it returns false
+     * to avoid telling the machinery in shadow to transform the actual file
+     * being visited and jarred up
+     *
+     * @return false 
+     */
+    boolean canTransformResource(FileTreeElement element) {
+        info.add(element.relativePath)
+        return false
+    }
+
+    /** No-op since we don't transform the actual file */
+    void transform(String path, InputStream is, List<Relocator> relocators) {
+        return
+    }
+
+    /**
+     * Confirm that we've done some work so our {@code modifyOutputStream} is called
+     *
+     * @return true
+     */
+    boolean hasTransformedResource() {
+        return true
+    }
+
+    /**
+     * Process the output stream and add our .jrubydir entries.
+     *
+     * This method will also clean up our tempdir to make sure we don't
+     * clutter the user's machine with junk
+     */
+    void modifyOutputStream(ZipOutputStream os) {
+        processDirectory(os, tmpDir)
+        deleteTempDirectory(tmpDir)
+    }
+
+    /**
+     * Process the directory given and ensure that all our .jrubydir files are added.
+     *
+     * @param stream {@link ZipOutputStream} for our archive being built
+     * @param directory Directory which contains our .jrubydir files to be
+     *  copied
+     */
+    protected void processDirectory(ZipOutputStream stream, File directory) {
+        directory.listFiles().each { File file ->
+            if (file.isDirectory()) {
+                processDirectory(stream, file)
+            }
+            else {
+                Path relative = Paths.get(tmpDir.absolutePath).relativize(Paths.get(file.absolutePath))
+                stream.putNextEntry(new ZipEntry(relative.toString()))
+                IOUtil.copy(new FileInputStream(file), stream)
+            }
+        }
+    }
+
+    /** Recursively delete the given {@link File} */
+    protected void deleteTempDirectory(File directory) {
+        directory.listFiles().each { File file ->
+            if (file.isDirectory()) {
+                deleteTempDirectory(file)
+            }
+            file.delete()
+        }
+        directory.delete()
+    }
+}
+

--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
@@ -1,0 +1,409 @@
+package com.github.jrubygradle.jar.internal
+
+/*
+ * This source code is derived from Apache 2.0 licensed software copyright John
+ * Engelman (https://github.com/johnrengelman) and was originally ported from this
+ * repository: https://github.com/johnrengelman/shadow
+*/
+
+import com.github.jengelman.gradle.plugins.shadow.impl.RelocatorRemapper
+import com.github.jengelman.gradle.plugins.shadow.internal.ZipCompressor
+import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
+import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import groovy.util.logging.Slf4j
+import org.apache.commons.io.FilenameUtils
+import org.apache.commons.io.IOUtils
+import org.apache.tools.zip.UnixStat
+import org.apache.tools.zip.Zip64RequiredException
+import org.apache.tools.zip.ZipEntry
+import org.apache.tools.zip.ZipFile
+import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.Action
+import org.gradle.api.GradleException
+import org.gradle.api.UncheckedIOException
+import org.gradle.api.file.FileCopyDetails
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.file.RelativePath
+import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.api.internal.file.CopyActionProcessingStreamAction
+import org.gradle.api.internal.file.copy.CopyAction
+import org.gradle.api.internal.file.copy.CopyActionProcessingStream
+import org.gradle.api.internal.file.copy.FileCopyDetailsInternal
+import org.gradle.api.internal.tasks.SimpleWorkResult
+import org.gradle.api.tasks.WorkResult
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.api.tasks.util.PatternSet
+import org.gradle.internal.UncheckedException
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.commons.RemappingClassAdapter
+
+import java.util.zip.ZipException
+
+/**
+ * JRubyJarCopyAction is an implementation of the {@link CopyAction} interface for mutating the JRubyJar archive.
+ *
+ * This class, in its current form is really just a big copy and paste of the
+ * shadow plugin's <a
+ * href="https://github.com/johnrengelman/shadow/blob/51f2b5916edd7690dca5e89e8b3a8f330d435423/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy">ShadowCopyAction</a>.
+ * with one notable exception, it disables the behavior of unzipping nested
+ * archives when creating the resulting archive.
+ *
+ * This class is only intended to be used with the {@link
+ * JRubyDirInfoTransformer} until such a time when this can be refactored to
+ * support the same behavior in a less hackish way.
+ */
+@Slf4j
+public class JRubyJarCopyAction implements CopyAction {
+
+    private final File zipFile
+    private final ZipCompressor compressor
+    private final DocumentationRegistry documentationRegistry
+    private final List<Transformer> transformers
+    private final List<Relocator> relocators
+    private final PatternSet patternSet
+
+    JRubyJarCopyAction(File zipFile, ZipCompressor compressor, DocumentationRegistry documentationRegistry,
+                            List<Transformer> transformers, List<Relocator> relocators, PatternSet patternSet) {
+
+        this.zipFile = zipFile
+        this.compressor = compressor
+        this.documentationRegistry = documentationRegistry
+        this.transformers = transformers
+        this.relocators = relocators
+        this.patternSet = patternSet
+    }
+
+    @Override
+    WorkResult execute(CopyActionProcessingStream stream) {
+        final ZipOutputStream zipOutStr
+
+        try {
+            zipOutStr = compressor.createArchiveOutputStream(zipFile)
+        } catch (Exception e) {
+            throw new GradleException("Could not create ZIP '${zipFile.toString()}'", e)
+        }
+
+        try {
+            withResource(zipOutStr, new Action<ZipOutputStream>() {
+                public void execute(ZipOutputStream outputStream) {
+                    try {
+                        stream.process(new StreamAction(outputStream, transformers, relocators, patternSet))
+                        processTransformers(outputStream)
+                    } catch (Exception e) {
+                        log.error('ex', e)
+                        //TODO this should not be rethrown
+                        throw e
+                    }
+                }
+            })
+        } catch (UncheckedIOException e) {
+            if (e.cause instanceof Zip64RequiredException) {
+                throw new Zip64RequiredException(
+                        String.format("%s\n\nTo build this archive, please enable the zip64 extension.\nSee: %s",
+                                e.cause.message, documentationRegistry.getDslRefForProperty(Zip, "zip64"))
+                )
+            }
+        }
+        return new SimpleWorkResult(true)
+    }
+
+    private void processTransformers(ZipOutputStream s) {
+        transformers.each { Transformer transformer ->
+            if (transformer.hasTransformedResource()) {
+                transformer.modifyOutputStream(s)
+            }
+        }
+    }
+
+    @SuppressWarnings('EmptyCatchBlock')
+    private static <T extends Closeable> void withResource(T resource, Action<? super T> action) {
+        try {
+            action.execute(resource);
+        } catch(Throwable t) {
+            try {
+                resource.close();
+            } catch (IOException e) {
+                // Ignored
+            }
+            throw UncheckedException.throwAsUncheckedException(t);
+        }
+
+        try {
+            resource.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    class StreamAction implements CopyActionProcessingStreamAction {
+
+        private final ZipOutputStream zipOutStr
+        private final List<Transformer> transformers
+        private final List<Relocator> relocators
+        private final RelocatorRemapper remapper
+        private final PatternSet patternSet
+
+        private Set<String> visitedFiles = new HashSet<String>()
+
+        public StreamAction(ZipOutputStream zipOutStr, List<Transformer> transformers, List<Relocator> relocators,
+                            PatternSet patternSet) {
+            this.zipOutStr = zipOutStr
+            this.transformers = transformers
+            this.relocators = relocators
+            this.remapper = new RelocatorRemapper(relocators)
+            this.patternSet = patternSet
+        }
+
+        public void processFile(FileCopyDetailsInternal details) {
+            if (details.directory) {
+                visitDir(details)
+            } else {
+                visitFile(details)
+            }
+        }
+        
+        private boolean recordVisit(RelativePath path) {
+            return visitedFiles.add(path.pathString)
+        }
+
+        private void visitFile(FileCopyDetails fileDetails) {
+            try {
+                boolean isClass = (FilenameUtils.getExtension(fileDetails.path) == 'class')
+                if (!remapper.hasRelocators() || !isClass) {
+                    if (!isTransformable(fileDetails)) {
+                        String mappedPath = remapper.map(fileDetails.relativePath.pathString)
+                        ZipEntry archiveEntry = new ZipEntry(mappedPath)
+                        archiveEntry.setTime(fileDetails.lastModified)
+                        archiveEntry.unixMode = (UnixStat.FILE_FLAG | fileDetails.mode)
+                        zipOutStr.putNextEntry(archiveEntry)
+                        fileDetails.copyTo(zipOutStr)
+                        zipOutStr.closeEntry()
+                    } else {
+                        transform(fileDetails)
+                    }
+                } else if (isClass) {
+                    remapClass(fileDetails)
+                }
+                recordVisit(fileDetails.relativePath)
+            } catch (Exception e) {
+                throw new GradleException(String.format("Could not add %s to ZIP '%s'.", fileDetails, zipFile), e)
+            }
+        }
+
+        private void visitArchiveDirectory(RelativeArchivePath archiveDir) {
+            if (recordVisit(archiveDir)) {
+                zipOutStr.putNextEntry(archiveDir.entry)
+                zipOutStr.closeEntry()
+            }
+        }
+
+        private void visitArchiveFile(ArchiveFileTreeElement archiveFile, ZipFile archive) {
+            def archiveFilePath = archiveFile.relativePath
+            if (archiveFile.classFile || !isTransformable(archiveFile)) {
+                if (recordVisit(archiveFilePath)) {
+                    if (!remapper.hasRelocators() || !archiveFile.classFile) {
+                        copyArchiveEntry(archiveFilePath, archive)
+                    } else {
+                        remapClass(archiveFilePath, archive)
+                    }
+                }
+            } else {
+                transform(archiveFile, archive)
+            }
+        }
+
+        private void addParentDirectories(RelativeArchivePath file) {
+            if (file) {
+                addParentDirectories(file.parent)
+                if (!file.file) {
+                    visitArchiveDirectory(file)
+                }
+            }
+        }
+
+        private void remapClass(RelativeArchivePath file, ZipFile archive) {
+            if (file.classFile) {
+                addParentDirectories(new RelativeArchivePath(new ZipEntry(remapper.mapPath(file) + '.class'), null))
+                remapClass(archive.getInputStream(file.entry), file.pathString)
+            }
+        }
+
+        private void remapClass(FileCopyDetails fileCopyDetails) {
+            if (FilenameUtils.getExtension(fileCopyDetails.name) == 'class') {
+                remapClass(fileCopyDetails.file.newInputStream(), fileCopyDetails.path)
+            }
+        }
+
+        private void remapClass(InputStream classInputStream, String path) {
+            InputStream is = classInputStream
+            ClassReader cr = new ClassReader(is)
+
+            // We don't pass the ClassReader here. This forces the ClassWriter to rebuild the constant pool.
+            // Copying the original constant pool should be avoided because it would keep references
+            // to the original class names. This is not a problem at runtime (because these entries in the
+            // constant pool are never used), but confuses some tools such as Felix' maven-bundle-plugin
+            // that use the constant pool to determine the dependencies of a class.
+            ClassWriter cw = new ClassWriter(0)
+
+            ClassVisitor cv = new RemappingClassAdapter(cw, remapper)
+
+            try {
+                cr.accept(cv, ClassReader.EXPAND_FRAMES)
+            } catch (Throwable ise) {
+                throw new GradleException("Error in ASM processing class " + path, ise)
+            }
+
+            byte[] renamedClass = cw.toByteArray()
+
+            // Need to take the .class off for remapping evaluation
+            String mappedName = remapper.mapPath(path)
+
+            try {
+                // Now we put it back on so the class file is written out with the right extension.
+                zipOutStr.putNextEntry(new ZipEntry(mappedName + ".class"))
+                IOUtils.copyLarge(new ByteArrayInputStream(renamedClass), zipOutStr)
+                zipOutStr.closeEntry()
+            } catch (ZipException e) {
+                log.warn("We have a duplicate " + mappedName + " in source project")
+            }
+        }
+
+        private void copyArchiveEntry(RelativeArchivePath archiveFile, ZipFile archive) {
+            String mappedPath = remapper.map(archiveFile.entry.name)
+            RelativeArchivePath mappedFile = new RelativeArchivePath(new ZipEntry(mappedPath), archiveFile.details)
+            addParentDirectories(mappedFile)
+            zipOutStr.putNextEntry(mappedFile.entry)
+            IOUtils.copyLarge(archive.getInputStream(archiveFile.entry), zipOutStr)
+            zipOutStr.closeEntry()
+        }
+
+        private void visitDir(FileCopyDetails dirDetails) {
+            try {
+                // Trailing slash in name indicates that entry is a directory
+                String path = dirDetails.relativePath.pathString + '/'
+                ZipEntry archiveEntry = new ZipEntry(path)
+                archiveEntry.setTime(dirDetails.lastModified)
+                archiveEntry.unixMode = (UnixStat.DIR_FLAG | dirDetails.mode)
+                zipOutStr.putNextEntry(archiveEntry)
+                zipOutStr.closeEntry()
+                recordVisit(dirDetails.relativePath)
+            } catch (Exception e) {
+                throw new GradleException(String.format("Could not add %s to ZIP '%s'.", dirDetails, zipFile), e)
+            }
+        }
+
+        private void transform(ArchiveFileTreeElement element, ZipFile archive) {
+            transform(element, archive.getInputStream(element.relativePath.entry))
+        }
+
+        private void transform(FileCopyDetails details) {
+            transform(details, details.file.newInputStream())
+        }
+
+        private void transform(FileTreeElement element, InputStream is) {
+            String mappedPath = remapper.map(element.relativePath.pathString)
+            transformers.find { it.canTransformResource(element) }.transform(mappedPath, is, relocators)
+        }
+
+        private boolean isTransformable(FileTreeElement element) {
+            return transformers.any { it.canTransformResource(element) }
+        }
+
+    }
+
+    class RelativeArchivePath extends RelativePath {
+
+        ZipEntry entry
+        FileCopyDetails details
+
+        RelativeArchivePath(ZipEntry entry, FileCopyDetails fileDetails) {
+            super(!entry.directory, entry.name.split('/'))
+            this.entry = entry
+            this.details = fileDetails
+        }
+
+        boolean isClassFile() {
+            return lastName.endsWith('.class')
+        }
+
+        RelativeArchivePath getParent() {
+            if (!segments || segments.length == 1) {
+                return null
+            } else {
+                //Parent is always a directory so add / to the end of the path
+                String path = segments[0..-2].join('/') + '/'
+                return new RelativeArchivePath(new ZipEntry(path), null)
+            }
+        }
+    }
+
+    class ArchiveFileTreeElement implements FileTreeElement {
+
+        private final RelativeArchivePath archivePath
+
+        ArchiveFileTreeElement(RelativeArchivePath archivePath) {
+            this.archivePath = archivePath
+        }
+
+        boolean isClassFile() {
+            return archivePath.classFile
+        }
+
+        @Override
+        File getFile() {
+            return null
+        }
+
+        @Override
+        boolean isDirectory() {
+            return archivePath.entry.directory
+        }
+
+        @Override
+        long getLastModified() {
+            return archivePath.entry.lastModifiedDate.time
+        }
+
+        @Override
+        long getSize() {
+            return archivePath.entry.size
+        }
+
+        @Override
+        InputStream open() {
+            return null
+        }
+
+        @Override
+        void copyTo(OutputStream outputStream) {
+
+        }
+
+        @Override
+        boolean copyTo(File file) {
+            return false
+        }
+
+        @Override
+        String getName() {
+            return archivePath.pathString
+        }
+
+        @Override
+        String getPath() {
+            return archivePath.lastName
+        }
+
+        @Override
+        RelativeArchivePath getRelativePath() {
+            return archivePath
+        }
+
+        @Override
+        int getMode() {
+            return archivePath.entry.unixMode
+        }
+    }
+}


### PR DESCRIPTION
The bug fixes to ensure `.jrubydir` generation gets corrected (see also jruby-gradle/jruby-gradle-storm-plugin#24) is (in my opinion) important enough to warrant getting out in a patch release while we shore up the 1.2.0 release.

