### PR TITLE
Allow manifest attributes to coexist with Main-Class

### DIFF
--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
@@ -213,9 +213,7 @@ class JRubyJar extends Jar {
                 exclude 'META-INF/maven/**/pom.xml'
             }
 
-            manifest = project.manifest {
-                attributes 'Main-Class': mainClass
-            }
+            manifest.attributes 'Main-Class': mainClass
         }
 
         if (scriptName != Type.RUNNABLE && scriptName != Type.LIBRARY) {

--- a/jruby-gradle-jar-plugin/src/test/groovy/com/github/jrubygradle/jar/JRubyJarPluginSpec.groovy
+++ b/jruby-gradle-jar-plugin/src/test/groovy/com/github/jrubygradle/jar/JRubyJarPluginSpec.groovy
@@ -126,6 +126,18 @@ class JRubyJarPluginSpec extends Specification {
         jarTask.manifest.attributes.'Main-Class' == 'org.scooby.doo.snackMain'
     }
 
+    def "Adding a main class and additional manifest attributes"() {
+        when: "Setting a main class"
+        project.configure(jarTask) {
+            mainClass 'org.scooby.doo.snackMain'
+            manifest.attributes('Class-Path': 'gangway.jar zoinks.jar')
+        }
+        jarTask.applyConfig()
+
+        then: "Then the Main-Class attribute does not erase other attributes"
+        jarTask.manifest.attributes.'Class-Path' == 'gangway.jar zoinks.jar'
+    }
+
     def "Setting up a java project"() {
         given: "All jar, java plugins have been applied"
         project = setupProject()


### PR DESCRIPTION
Currently adding manifest attributes is impossible when the `Main-Class` is provided. This means it's only possible in non-runnable jars. Which pretty much makes `Class-Path` manifest attribute unusable.

I've added a spec that showcases the issue. I've also added a fix that works for me. But would best be reviewed since it rewrites a fix made in https://github.com/jruby-gradle/jruby-gradle-plugin/commit/eedfe8237253594da517fb77437976f7611d59b0

