### PR TITLE
Allow JRubJar jar-dependencies to be upgraded

### DIFF
--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
@@ -274,6 +274,7 @@ class JRubyJar extends Jar {
     void addEmbeddedDependencies(Configuration config) {
         /* To ensure that we can load our jars properly, we should always have
          * jar-dependencies in our resolution graph */
+        project.dependencies.add(config.name, 'rubygems:jar-dependencies:[0.1.15,)')
     }
 
     /** Update the staging directory and tasks responsible for setting it up */

--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
@@ -274,7 +274,6 @@ class JRubyJar extends Jar {
     void addEmbeddedDependencies(Configuration config) {
         /* To ensure that we can load our jars properly, we should always have
          * jar-dependencies in our resolution graph */
-        project.dependencies.add(config.name, 'rubygems:jar-dependencies:0.1.15')
     }
 
     /** Update the staging directory and tasks responsible for setting it up */


### PR DESCRIPTION


This is a rework of #271, with an accompanying test, which I believe meets @wenhoujx's needs