### PR TITLE
Mkmf compatibility

### DIFF
--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
@@ -95,7 +95,8 @@ class GemUtils {
                 // jbundler and/or jar-dependencies will not attempt to invoke
                 // Maven on a gem's behalf to install a Java dependency that we
                 // should already have taken care of, see #79
-                setEnvironment 'JBUNDLE_SKIP' : true, 'JARS_SKIP' : true
+                environment 'JBUNDLE_SKIP', true
+                environment 'JARS_SKIP', true
                 main JRUBY_MAINCLASS
                 classpath jRubyClasspath
                 args '-S', GEM, 'install'

--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/GemUtils.groovy
@@ -95,8 +95,10 @@ class GemUtils {
                 // jbundler and/or jar-dependencies will not attempt to invoke
                 // Maven on a gem's behalf to install a Java dependency that we
                 // should already have taken care of, see #79
-                environment 'JBUNDLE_SKIP', true
-                environment 'JARS_SKIP', true
+                environment JBUNDLE_SKIP : true,
+                            JARS_SKIP : true,
+                            GEM_HOME : destDir.absolutePath,
+                            GEM_PATH : destDir.absolutePath
                 main JRUBY_MAINCLASS
                 classpath jRubyClasspath
                 args '-S', GEM, 'install'


### PR DESCRIPTION
I am trying to get capybara webkit to install in jruby-gradle (on Windows). I am slowly getting there. This has been possible in JRuby for a few weeks now since the `mkmf` module (MakeMakefile) has been introduced. But I encountered two problems in jruby-gradle and I have fixes for them...

* The first is to get rid of the call to `setEnvironment`. With the code in master I get this error:
  ```
  'java' is not recognized as an internal or external command, operable program or batch file.
  ```
  ... `setEnvironment` appears to remove existing environment variables instead of just adding the two new ones. By using the alternative `environment` function I was able to fix this.

* The second one is a bit more tricky. Using `GEM_HOME=/some/directory gem install` appears to differ from `gem install --install-dir=/some/directory/`. The difference is that `GEM_HOME` can also be used for temporary log files. Which is something that `mkmf` does while building capybara-webkit.