### PR TITLE
Resolve jruby-rack dependancy

### DIFF
--- a/jruby-gradle-war-plugin/src/main/groovy/com/github/jrubygradle/war/JRubyWar.groovy
+++ b/jruby-gradle-war-plugin/src/main/groovy/com/github/jrubygradle/war/JRubyWar.groovy
@@ -65,7 +65,7 @@ class JRubyWar extends War {
     static void updateJRubyDependencies(Project project) {
         project.dependencies {
             jrubyWar "org.jruby:jruby-complete:${project.jruby.defaultVersion}"
-            jrubyWar('org.jruby.rack:jruby:rack:[1.1.0,2.0)') {
+            jrubyWar('org.jruby.rack:jruby-rack:[1.1.0,2.0)') {
                 exclude module: 'jruby-complete'
             }
         }


### PR DESCRIPTION
Changed 
`org.jruby.rack:jruby:rack`
to 
`org.jruby.rack:jruby-rack`
so that it can resolve

Fix for Issue #276 