### PR TITLE
Fixes #293 - Environment Variables not Passes to javaexec

### DIFF
--- a/jruby-gradle-base-plugin/src/integTest/groovy/com/github/jrubygradle/JRubyExecExtensionIntegrationSpec.groovy
+++ b/jruby-gradle-base-plugin/src/integTest/groovy/com/github/jrubygradle/JRubyExecExtensionIntegrationSpec.groovy
@@ -138,4 +138,30 @@ class JRubyExecExtensionIntegrationSpec extends Specification {
         new File(project.buildDir, customGemDir).exists()
 
     }
+
+    def "Running a script that requires environment variables"() {
+        // This tests that the passthrough invocation
+        // happens for overloaded versions of environment
+        // and that the environment variables are passed
+        // on to the script
+        given:
+        final String envVarName = 'TEST_ENV_VAR'
+        final String envVarValue = 'Test Value'
+        final Map envVarMap = [TEST_A: 'A123', TEST_B: 'B123']
+
+        when:
+        project.with {
+            jrubyexec {
+                environment    envVarName, envVarValue
+                environment    envVarMap
+                script         "${TEST_SCRIPT_DIR}/envVars.rb"
+                standardOutput output
+            }
+        }
+
+        then:
+        outputBuffer =~ /TEST_ENV_VAR=Test Value/
+        outputBuffer =~ /TEST_A=A123/
+        outputBuffer =~ /TEST_B=B123/
+    }
 }

--- a/jruby-gradle-base-plugin/src/integTest/resources/scripts/envVars.rb
+++ b/jruby-gradle-base-plugin/src/integTest/resources/scripts/envVars.rb
@@ -1,0 +1,1 @@
+puts ENV.map { |k, v| "#{k}=#{v}" }.join("\n")

--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
@@ -55,6 +55,7 @@ class JRubyExecDelegate implements JRubyExecTraits   {
 
     private final List passthrough = []
 
+    @SuppressWarnings('VariableName')
     static Object jrubyexecDelegatingClosure = { Project project, Closure cl ->
         JRubyExecDelegate proxy =  new JRubyExecDelegate()
         proxy.project = project

--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
@@ -70,7 +70,7 @@ class JRubyExecDelegate implements JRubyExecTraits   {
             proxy.passthrough.each { item ->
                 Object k = item.keySet()[0]
                 Object v = item.values()[0]
-                "${k}" v
+                invokeMethod("${k}", v)
             }
             main 'org.jruby.Main'
             // just keep this even if it does not exists
@@ -81,7 +81,14 @@ class JRubyExecDelegate implements JRubyExecTraits   {
                 args item.toString()
             }
 
-            setEnvironment proxy.getPreparedEnvironment(System.env)
+            // Start with System.env then add from environment,
+            // which will add the user settings and
+            // overwrite any overlapping entries
+            final env = [:]
+            env << System.env
+            env << environment
+
+            setEnvironment proxy.getPreparedEnvironment(env)
         }
     }
 

--- a/jruby-gradle-base-plugin/src/test/groovy/com/github/jrubygradle/internal/JRubyExecDelegateSpec.groovy
+++ b/jruby-gradle-base-plugin/src/test/groovy/com/github/jrubygradle/internal/JRubyExecDelegateSpec.groovy
@@ -76,6 +76,7 @@ class JRubyExecDelegateSpec extends Specification {
     def "When just passing arbitrary javaexec, expect them to be stored"() {
         given:
             def cl = {
+                environment 'XYZ', '123'
                 executable '/path/to/file'
                 jvmArgs '-x'
                 jvmArgs '-y','-z'
@@ -84,12 +85,14 @@ class JRubyExecDelegateSpec extends Specification {
             cl.call()
 
         expect:
-            jred.valuesAt(0) == '/path/to/file'
-            jred.valuesAt(1) == '-x'
-            jred.valuesAt(2) == ['-y','-z']
-            jred.keyAt(0) == 'executable'
-            jred.keyAt(1) == 'jvmArgs'
+            jred.valuesAt(0) == ['XYZ', '123']
+            jred.valuesAt(1) == '/path/to/file'
+            jred.valuesAt(2) == '-x'
+            jred.valuesAt(3) == ['-y','-z']
+            jred.keyAt(0) == 'environment'
+            jred.keyAt(1) == 'executable'
             jred.keyAt(2) == 'jvmArgs'
+            jred.keyAt(3) == 'jvmArgs'
 
     }
 


### PR DESCRIPTION
This fixes two problems:

1. That JRubyExecDelegate was not passing on environment variables to `javaexec`. It was replacing them with `System.env`.
2. That certain overloaded versions of the `environment()` method were not being properly looked up by just doing `"${k}" v`. It was replaced with `invokeMethod` and now seems to look up the method correctly for different cases.

The following integration tests were already failing before I made any changes:

```
com.github.jrubygradle.JRubyExecIntegrationSpec > Running a script that requires a gem using custom embedded rubygems-servlets maven repo FAILED
com.github.jrubygradle.JRubyPrepareGemsIntegrationSpec > Check if rack version gets resolved FAILED
com.github.jrubygradle.JRubyPrepareGemsIntegrationSpec > Check if prerelease gem gets resolved FAILED
```