### PR TITLE
switch to latest jruby-mains version

### DIFF
--- a/jruby-gradle-jar-plugin/build.gradle
+++ b/jruby-gradle-jar-plugin/build.gradle
@@ -28,7 +28,7 @@ dependencies {
         transitive = false
     }
 
-    testRepo ('org.jruby.mains:jruby-mains:0.4.0') {
+    testRepo ('org.jruby.mains:jruby-mains:0.6.1') {
         transitive = false
     }
 

--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
@@ -34,7 +34,7 @@ class JRubyJar extends Jar {
     static final String DEFAULT_JRUBYJAR_CONFIG = 'jrubyJar'
     static final String DEFAULT_MAIN_CLASS = 'org.jruby.mains.JarMain'
     static final String EXTRACTING_MAIN_CLASS = 'org.jruby.mains.ExtractingMain'
-    static final String DEFAULT_JRUBY_MAINS = '0.4.0'
+    static final String DEFAULT_JRUBY_MAINS = '0.6.1'
 
     /**
      * @return Directory that the dependencies for this project will be staged into


### PR DESCRIPTION
fixes an issue with puma and `Bundler`. puma checks for `defined?Bunder` and the old jruby-mains did define it even if bundler was not used at all. this of course confuses puma.