### PR TITLE
Fix for Cannot change strategy of configuration after it has been res…

### DIFF
--- a/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/GemVersionResolver.groovy
+++ b/jruby-gradle-base-plugin/src/main/groovy/com/github/jrubygradle/internal/GemVersionResolver.groovy
@@ -16,7 +16,7 @@ class GemVersionResolver {
     private final Logger logger
 
     static void setup(Project project) {
-        project.configurations.each {
+        project.configurations.find { it.name == "gems" }.with {
             new GemVersionResolver(project.logger, it)
         }
     }


### PR DESCRIPTION
Resolver goes over all configs/deps while ignores most of them. If other dep management plugins are used then the resolver will fail:

Caused by: org.gradle.api.InvalidUserDataException: Cannot change strategy of configuration ':buildTimeConfigRuntimeClasspath' after it has been resolved.
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.preventIllegalMutation(DefaultConfiguration.java:786)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.validateMutation(DefaultConfiguration.java:757)
        at org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy.eachDependency(DefaultResolutionStrategy.java:135)
        at org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy_Decorated.eachDependency(Unknown Source)
        at org.gradle.internal.metaobject.BeanDynamicObject$MetaClassAdapter.invokeMethod(BeanDynamicObject.java:479)
        at org.gradle.internal.metaobject.BeanDynamicObject.tryInvokeMethod(BeanDynamicObject.java:191)
        at org.gradle.internal.metaobject.CompositeDynamicObject.tryInvokeMethod(CompositeDynamicObject.java:98)
        at org.gradle.internal.metaobject.MixInClosurePropertiesAsMethodsDynamicObject.tryInvokeMethod(MixInClosurePropertiesAsMethodsDynamicObject.java:30)
        at org.gradle.internal.metaobject.ConfigureDelegate.invokeMethod(ConfigureDelegate.java:57)
        at com.github.jrubygradle.internal.GemVersionResolver$_closure1.doCall(GemVersionResolver.groovy:28)
        at org.gradle.api.internal.ClosureBackedAction.execute(ClosureBackedAction.java:71)
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:160)
        at org.gradle.util.ConfigureUtil.configure(ConfigureUtil.java:106)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolutionStrategy(DefaultConfiguration.java:725)
        at org.gradle.api.artifacts.Configuration$resolutionStrategy.call(Unknown Source)
        at com.github.jrubygradle.internal.GemVersionResolver.<init>(GemVersionResolver.groovy:27)
        at com.github.jrubygradle.internal.GemVersionResolver$_setup_closure2.doCall(GemVersionResolver.groovy:20)
        at com.github.jrubygradle.internal.GemVersionResolver.setup(GemVersionResolver.groovy:19)
        at com.github.jrubygradle.internal.GemVersionResolver$setup.call(Unknown Source)
        at com.github.jrubygradle.JRubyPlugin$_apply_closure1.doCall(JRubyPlugin.groovy:42)

Putting resolver with that change in buildSrc fixes the issue.