### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: true
 #env:
 #  - GRADLE_OPTS="-Xmx768m -Xms256m -Xss1m"
 script:
-  - ./gradlew -S -i --max-workers=2 --no-daemon clean check build
+  - ./gradlew -S -i --max-workers=2 --no-daemon clean check build --scan
 jdk:
   - openjdk8
 os:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ build:
   verbosity: detailed
 
 build_script:
-  - gradlew.bat assemble --info --no-daemon
+  - gradlew.bat assemble --info --no-daemon --scan
 
 test_script:
-  - gradlew.bat test check gradleTest --info --no-daemon
+  - gradlew.bat test check gradleTest --info --no-daemon --scan
 
 branches:
   only:

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
     id 'org.ysb33r.gradletest' version '2.0-alpha-8' apply false
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'org.ajoberstar.github-pages' version '1.2.0' apply false
 }
 
-
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
 
 allprojects {
     apply plugin: 'idea'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.daemon=true
+org.gradle.caching=true
 org.gradle.parallel=false
 org.gradle.configureondemand=false
 


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.