### PR TITLE
use WorkResults.didWork() instead of deprecated SimpleWorkResult

### DIFF
--- a/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
+++ b/jruby-gradle-jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.internal.file.copy.CopyAction
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal
-import org.gradle.api.internal.tasks.SimpleWorkResult
+import org.gradle.api.tasks.WorkResults
 import org.gradle.api.tasks.WorkResult
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.util.PatternSet
@@ -108,7 +108,7 @@ class JRubyJarCopyAction implements CopyAction {
                 )
             }
         }
-        return new SimpleWorkResult(true)
+        return WorkResults.didWork(true)
     }
 
     private void processTransformers(ZipOutputStream s) {


### PR DESCRIPTION
Use `WorkResults.didWork()` instead of deprecated `SimpleWorkResult`.

Only caveat: `WorkResults.didWork()` first appeared in Gradle 4.2. Making this the minimum required version.