### PR TITLE
Sync JRubyJarCopyAction with the upstream/originating shadow code

### DIFF
--- a/jar-plugin/build.gradle
+++ b/jar-plugin/build.gradle
@@ -17,7 +17,14 @@ generateTestConfig {
 
 dependencies {
     compile project(':jruby-gradle-plugin')
-    compile 'com.github.jengelman.gradle.plugins:shadow:[1.2.2,2.0)'  // NEED TO FIX THIS OPEN END
+    /*
+     * NOTE: version 5.0.0 of the shadow plugin supports only Gradle 5.x and later
+     */
+    compile 'com.github.jengelman.gradle.plugins:shadow:[4.0.2,5.0)'
+    compile 'org.codehaus.plexus:plexus-utils:[3.2.0,3.3)'
+    compile 'org.apache.commons:commons-io:1.3.2'
+    compile 'org.ow2.asm:asm-commons:[6.1,6.99)'
+    compile 'org.apache.ant:ant:[1.10.6,2.0)'
 
     testCompile (spockVersion) {
         exclude module : 'groovy-all'

--- a/jar-plugin/build.gradle
+++ b/jar-plugin/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     /*
      * NOTE: version 5.0.0 of the shadow plugin supports only Gradle 5.x and later
      */
-    compile 'com.github.jengelman.gradle.plugins:shadow:[4.0.2,5.0)'
+    compile 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
     compile 'org.codehaus.plexus:plexus-utils:[3.2.0,3.3)'
     compile 'org.apache.commons:commons-io:1.3.2'
     compile 'org.ow2.asm:asm-commons:[6.1,6.99)'

--- a/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
+++ b/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/JRubyJar.groovy
@@ -1,11 +1,17 @@
 package com.github.jrubygradle.jar
 
-import com.github.jengelman.gradle.plugins.shadow.internal.GradleVersionUtil
+/*
+ * These two internal imports from the Shadow plugin are unavoidable because of
+ * the expected internals of ShadowCopyAction
+ */
+import com.github.jengelman.gradle.plugins.shadow.internal.DefaultZipCompressor
 import com.github.jengelman.gradle.plugins.shadow.internal.ZipCompressor
+
 import com.github.jrubygradle.JRubyPrepare
 import com.github.jrubygradle.jar.internal.JRubyDirInfoTransformer
 import com.github.jrubygradle.jar.internal.JRubyJarCopyAction
 import groovy.transform.PackageScope
+import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.DuplicatesStrategy
@@ -15,6 +21,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.bundling.ZipEntryCompression
 
 /**
  * JRubyJar creates a Java Archive with Ruby code packed inside of it.
@@ -240,7 +247,6 @@ class JRubyJar extends Jar {
         appendix = 'jruby'
         /* Make sure our default configuration is present regardless of whether we use it or not */
         prepareTask = project.task("prepare${prepareNameForSuffix(name)}", type: JRubyPrepare)
-        versionUtil = new GradleVersionUtil(getProject().getGradle().getGradleVersion())
         dependsOn prepareTask
 
         // TODO get rid of this and try to adjust the CopySpec for the gems
@@ -297,7 +303,6 @@ class JRubyJar extends Jar {
                 [new JRubyDirInfoTransformer()], /* transformers */
                 [], /* relocators */
                 mainSpec.buildRootResolver().getPatternSet(), /* patternSet */
-                versionUtil, /* util */
                 false, /* preserveFileTimestamps */
                 false, /* minimizeJar */
                 null /* unusedTracker */
@@ -307,7 +312,14 @@ class JRubyJar extends Jar {
 
     @Internal
     protected ZipCompressor getInternalCompressor() {
-        return versionUtil.getInternalCompressor(getEntryCompression(), this)
+        switch (entryCompression) {
+            case ZipEntryCompression.DEFLATED:
+                return new DefaultZipCompressor(this.zip64, ZipOutputStream.DEFLATED)
+            case ZipEntryCompression.STORED:
+                return new DefaultZipCompressor(this.zip64, ZipOutputStream.STORED)
+            default:
+                throw new IllegalArgumentException(String.format('Unknown Compression type %s', entryCompression))
+        }
     }
 
     /**
@@ -329,5 +341,4 @@ class JRubyJar extends Jar {
     protected String embeddedJRubyMainsVersion = DEFAULT_JRUBY_MAINS
     protected String jarConfiguration = DEFAULT_JRUBYJAR_CONFIG
     protected String jarMainClass
-    protected GradleVersionUtil versionUtil
 }

--- a/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfoTransformer.groovy
+++ b/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfoTransformer.groovy
@@ -4,13 +4,13 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-import org.apache.tools.zip.ZipOutputStream
 import org.apache.tools.zip.ZipEntry
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
 
-import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
+import shadow.org.apache.tools.zip.ZipOutputStream
 import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 
 /**
  * JRubyDirInfoTransformer implements a {@link Transformer} interface.
@@ -44,7 +44,7 @@ class JRubyDirInfoTransformer implements Transformer {
     }
 
     /** No-op since we don't transform the actual file */
-    void transform(String path, InputStream is, List<Relocator> relocators) {
+    void transform(TransformerContext context) {
         return
     }
 
@@ -63,7 +63,7 @@ class JRubyDirInfoTransformer implements Transformer {
      * This method will also clean up our tempdir to make sure we don't
      * clutter the user's machine with junk
      */
-    void modifyOutputStream(ZipOutputStream os) {
+    void modifyOutputStream(ZipOutputStream os, boolean preserveFileTimestamps) {
         processDirectory(os, tmpDir)
         deleteTempDirectory(tmpDir)
     }

--- a/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfoTransformer.groovy
+++ b/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyDirInfoTransformer.groovy
@@ -4,7 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-import org.apache.tools.zip.ZipEntry
+import shadow.org.apache.tools.zip.ZipEntry
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.api.file.FileTreeElement
 

--- a/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
+++ b/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
@@ -7,7 +7,6 @@ package com.github.jrubygradle.jar.internal
 */
 
 import com.github.jengelman.gradle.plugins.shadow.impl.RelocatorRemapper
-import com.github.jengelman.gradle.plugins.shadow.internal.GradleVersionUtil
 import com.github.jengelman.gradle.plugins.shadow.internal.UnusedTracker
 import com.github.jengelman.gradle.plugins.shadow.internal.ZipCompressor
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
@@ -33,6 +32,7 @@ import org.gradle.api.internal.file.copy.CopyAction
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal
 import org.gradle.api.tasks.WorkResult
+import org.gradle.api.tasks.WorkResults
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.UncheckedException
@@ -69,14 +69,13 @@ class JRubyJarCopyAction implements CopyAction {
     private final List<Relocator> relocators
     private final PatternSet patternSet
     private final String encoding
-    private final GradleVersionUtil versionUtil
     private final boolean preserveFileTimestamps
     private final boolean minimizeJar
     private final UnusedTracker unusedTracker
 
     JRubyJarCopyAction(File zipFile, ZipCompressor compressor, DocumentationRegistry documentationRegistry,
                             String encoding, List<Transformer> transformers, List<Relocator> relocators,
-                            PatternSet patternSet, GradleVersionUtil util,
+                            PatternSet patternSet,
                             boolean preserveFileTimestamps, boolean minimizeJar, UnusedTracker unusedTracker) {
 
         this.zipFile = zipFile
@@ -86,7 +85,6 @@ class JRubyJarCopyAction implements CopyAction {
         this.relocators = relocators
         this.patternSet = patternSet
         this.encoding = encoding
-        this.versionUtil = util
         this.preserveFileTimestamps = preserveFileTimestamps
         this.minimizeJar = minimizeJar
         this.unusedTracker = unusedTracker
@@ -141,7 +139,7 @@ class JRubyJarCopyAction implements CopyAction {
                 )
             }
         }
-        return versionUtil.getWorkResult(true)
+        return WorkResults.didWork(true)
     }
 
     private void processTransformers(ZipOutputStream stream) {

--- a/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
+++ b/jar-plugin/src/main/groovy/com/github/jrubygradle/jar/internal/JRubyJarCopyAction.groovy
@@ -37,7 +37,7 @@ import org.gradle.internal.UncheckedException
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.commons.RemappingClassAdapter
+import org.objectweb.asm.commons.ClassRemapper
 
 import java.util.zip.ZipException
 
@@ -235,7 +235,7 @@ class JRubyJarCopyAction implements CopyAction {
             // that use the constant pool to determine the dependencies of a class.
             ClassWriter cw = new ClassWriter(0)
 
-            ClassVisitor cv = new RemappingClassAdapter(cw, remapper)
+            ClassVisitor cv = new ClassRemapper(cw, remapper)
 
             try {
                 cr.accept(cv, ClassReader.EXPAND_FRAMES)


### PR DESCRIPTION
Unfortunately as of v4.0.4, the shadow plugin for Gradle still explodes all the nested `.jar` files rather than injecting them into the shadow file properly, so `JRubyJarCopyAction` is still needed.

This pull request effectively syncs our tree with 4.0.4 and puts us on good footing for the future.

Closes #307 