### PR TITLE
Annotate task properties

### DIFF
--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
@@ -150,6 +150,7 @@ class JRubyExec extends JavaExec implements JRubyExecTraits {
      * @throw {@code org.gradle.api.InvalidUserDataException} if mode of behaviour cannot be determined.
      */
     @Override
+    @Input
     @SuppressWarnings('UnnecessaryGetter')
     List<String> getArgs() {
         // just add the extra load-path even if it does not exists

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPrepare.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPrepare.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -46,6 +47,7 @@ class JRubyPrepare extends DefaultTask {
         outputDir = f
     }
 
+    @Internal
     List<Object> dependencies = []
 
     @Optional


### PR DESCRIPTION
Simple change, but getters/properties in tasks should all be annotated.