### PR TITLE
Allow script author to bypass Bundler-like strategy for resolving dependencies

### DIFF
--- a/core-plugin/src/integTest/groovy/com/github/jrubygradle/api/core/IvyXmlProxyServerIntegrationSpec.groovy
+++ b/core-plugin/src/integTest/groovy/com/github/jrubygradle/api/core/IvyXmlProxyServerIntegrationSpec.groovy
@@ -167,6 +167,27 @@ class IvyXmlProxyServerIntegrationSpec extends Specification {
         findFiles ~/^jruby-openssl-0.10.2-java.gem$/
     }
 
+    @Issue('https://github.com/jruby-gradle/jruby-gradle-plugin/issues/325')
+    void 'Resolve a prerelease GEM by excluding from GEM strategy'() {
+        setup:
+        withBuildFile '''
+        gemResolverStrategy {
+            excludeModule ~/^asciidoctor-pdf$/, ~/.+(alpha|beta).*/ 
+        }
+        
+        dependencies {
+            something 'rubygems:asciidoctor-pdf-cjk-kai_gen_gothic:0.1.1'
+            something 'rubygems:asciidoctor-pdf:1.5.0.alpha.8'
+        }
+        '''
+
+        when:
+        build()
+
+        then:
+        findFiles (~/^asciidoctor-pdf.*\.gem$/).size() == 3
+    }
+
     private List<File> findFiles(Pattern pat) {
         new File(projectDir, 'build/something').listFiles(new FilenameFilter() {
             @Override

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/JRubyCorePlugin.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/JRubyCorePlugin.groovy
@@ -23,7 +23,7 @@
  */
 package com.github.jrubygradle.api.core
 
-import com.github.jrubygradle.api.gems.GemGroups
+import com.github.jrubygradle.api.gems.GemResolverStrategy
 import com.github.jrubygradle.internal.gems.GemVersionResolver
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
@@ -42,7 +42,7 @@ import org.gradle.api.plugins.ExtensionAware
 class JRubyCorePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        GemGroups gemGroups = project.extensions.create(GemGroups.NAME, GemGroups)
+        GemResolverStrategy gemGroups = project.extensions.create(GemResolverStrategy.NAME, GemResolverStrategy)
 
         ((ExtensionAware) project.repositories).extensions.create(
             RepositoryHandlerExtension.NAME,

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/RepositoryHandlerExtension.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/RepositoryHandlerExtension.groovy
@@ -23,7 +23,7 @@
  */
 package com.github.jrubygradle.api.core
 
-import com.github.jrubygradle.api.gems.GemGroups
+import com.github.jrubygradle.api.gems.GemResolverStrategy
 import com.github.jrubygradle.internal.core.IvyXmlGlobalProxyRegistry
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
@@ -111,7 +111,7 @@ class RepositoryHandlerExtension {
         String group
     ) {
         IvyXmlProxyServer proxy = ivyProxies.registerProxy(serverUri, group)
-        project.extensions.getByType(GemGroups).addGemGroup(group)
+        project.extensions.getByType(GemResolverStrategy).addGemGroup(group)
         restrictToGems(createIvyRepo(serverUri, proxy.bindAddress), group)
     }
 

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/gems/GemResolverStrategy.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/gems/GemResolverStrategy.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2014-2019, R. Tyler Croy <rtyler@brokenco.de>,
+ *     Schalk Cronje <ysb33r@gmail.com>, Christian Meier, Lookout, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.github.jrubygradle.api.gems
+
+import com.github.jrubygradle.api.core.RepositoryHandlerExtension
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ModuleVersionSelector
+
+import java.util.regex.Pattern
+
+/** Defines groups which contains GEMs and controls GEM resolving rules.
+ *
+ * @author Schalk W. Cronjé
+ *
+ * @since 2.0
+ */
+@CompileStatic
+class GemResolverStrategy {
+
+    public static final String NAME = 'gemResolverStrategy'
+
+    /** Is this group/organisation a GEM group ?
+     *
+     * @param groupName Name of group/organisation.
+     * @return {@code true} is group is a GEM group.
+     */
+    boolean isGemGroup(final String groupName) {
+        groups.contains(groupName)
+    }
+
+    /** Add a new group for GEMs.
+     *
+     * @param groupName Name of group to add.
+     */
+    void addGemGroup(final String groupName) {
+        groups.add(groupName)
+    }
+
+    /** Exclude a configuration from being resolved using the GEM
+     *  version resolver strategy.
+     *
+     * @param configs Configurations to be excluded
+     */
+    void excludeConfigurations(Configuration... configs) {
+        this.excludedConfigurations.addAll(configs*.name)
+    }
+
+    /** Exclude a configuration from being resolved using the GEM
+     *  version resolver strategy.
+     *
+     * @param configs Configurations to be excluded
+     */
+    void excludeConfigurations(String... configs) {
+        this.excludedConfigurations.addAll(configs)
+    }
+
+    /** Exclude a module from being resolved using the GEM version resolver
+     * strategy.
+     *
+     * @param name Module name. Never {@code null}.
+     * @param version Version. Can be {@code null}.
+     */
+    void excludeModule(String name, String version = null) {
+        excludedModules.add(new Matcher(
+            module: Pattern.compile(Pattern.quote(name)),
+            version: version ? Pattern.compile(Pattern.quote(version)) : null
+        ))
+    }
+
+    /** Exclude a module from being resolved using the GEM version resolver
+     * strategy.
+     *
+     * @param namePattern Pattern for name. Never {@code null}.
+     * @param versionPattern Pattern for version. Can be {@code null}
+     */
+    void excludeModule(Pattern namePattern, Pattern versionPattern = null) {
+        excludedModules.add(new Matcher(module: namePattern, version: versionPattern))
+    }
+
+    /** Whether the GEM version resolving strategy should be applied for a specific module.
+     *
+     * In most cases this will alsways be {@code true} unless a specific rule excludes it.
+     *
+     * @param mvs Module version selector
+     * @return Whether the Bundler-like version selector atregty may be applied
+     */
+    boolean useGemVersionResolver(ModuleVersionSelector mvs) {
+        isGemGroup(mvs.group) && excludedModules.find { it.match(mvs.name, mvs.version) }
+    }
+
+    /** Whether the GEM version resolving strategy should be applied to a specific configuration.
+     *
+     * In most cases this will always be {@code true} unless a specific rule excludes it.
+     *
+     * @param configurationName Name fo configuration
+     * @return Whether the Bundler-like version selector strategy may be applied
+     */
+    boolean useGemVersionResolver(String configurationName) {
+        configurationName in excludedConfigurations
+    }
+
+    @EqualsAndHashCode
+    private class Matcher {
+        Pattern module
+        Pattern version
+
+        boolean match(String name, String ver) {
+            name =~ module && (this.version == null || ver ==~ this.version)
+        }
+    }
+
+    private final Set<Matcher> excludedModules = [].toSet()
+    private final Set<String> excludedConfigurations = [].toSet()
+    private final Set<String> groups = [RepositoryHandlerExtension.DEFAULT_GROUP_NAME].toSet()
+}

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/internal/gems/GemVersionResolver.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/internal/gems/GemVersionResolver.groovy
@@ -25,6 +25,7 @@ package com.github.jrubygradle.internal.gems
 
 import com.github.jrubygradle.api.gems.GemVersion
 import com.github.jrubygradle.api.gems.GemGroups
+import groovy.transform.CompileDynamic
 import groovy.transform.PackageScope
 import org.gradle.api.Action
 import org.gradle.api.GradleException
@@ -32,6 +33,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyResolveDetails
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.util.GradleVersion
 
 import static com.github.jrubygradle.api.gems.GemVersion.gemVersionFromGradleIvyRequirement
 
@@ -81,6 +83,8 @@ class GemVersionResolver {
             logger.debug("${configuration}      resolved  ${next}")
 
             details.useVersion(next.toString())
+            withReason(details,"Selected by GEM Version Resolver")
+
         } else {
             GemVersion next = gemVersionFromGradleIvyRequirement(details.requested.version)
             versions[details.requested.name] = next
@@ -113,9 +117,17 @@ class GemVersionResolver {
         )
     }
 
+    @CompileDynamic
+    void withReason(DependencyResolveDetails drd, String reason) {
+        if(HAS_BECAUSE_PROPERTY) {
+            drd.because(reason)
+        }
+    }
+
     @PackageScope
     static final GemVersionResolver NULL_RESOLVER = new GemVersionResolver()
 
+    private static final HAS_BECAUSE_PROPERTY = GradleVersion.current() >= GradleVersion.version('4.5')
     private static final String DBG_SEPARATOR = '                       ------------------------'
     private final Map versions = [:]
     private final Configuration configuration


### PR DESCRIPTION
Sometimes it is convenient to not use the Bundler-like strategy from GemVersionResolver, especially in the cases of pre-releases.

This PR depends on #373 being merged first.