### PR TITLE
Prepare for Gradle's configuration cache

### DIFF
--- a/base-plugin/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
+++ b/base-plugin/src/integTest/groovy/com/github/jrubygradle/JRubyPrepareGemsIntegrationSpec.groovy
@@ -73,7 +73,7 @@ class JRubyPrepareGemsIntegrationSpec extends IntegrationSpecification {
         then:
         // since we need a version range in the setup the
         // resolved version here can vary over time
-        new File(projectDir, "gems/rack-1.6.12").exists()
+        new File(projectDir, "gems/rack-1.6.13").exists()
     }
 
     void "Check if selenium-webdriver version gets resolved"() {

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/GenerateGradleRb.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/GenerateGradleRb.groovy
@@ -29,16 +29,18 @@ import groovy.transform.CompileStatic
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.ysb33r.grolifant.api.StringUtils
+import org.ysb33r.grolifant.api.core.ProjectOperations
+import org.ysb33r.grolifant.api.v4.StringUtils
 
 import static com.github.jrubygradle.internal.JRubyExecUtils.classpathFromConfiguration
 
-/** Generate a LOAD_PATH Ruby file whichi is loadable by Ruby scripts when
+/** Generate a LOAD_PATH Ruby file which is loadable by Ruby scripts when
  * performing local manual testing.
  *
  * @author Schalk W. Cronjé
@@ -53,6 +55,7 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
 
     GenerateGradleRb() {
         this.jruby = extensions.create(JRubyPluginExtension.NAME, JRubyPluginExtension, this)
+        this.projectOperations = ProjectOperations.create(project)
     }
 
     void destinationDir(Object dest) {
@@ -72,7 +75,7 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
     }
 
     File getDestinationDir() {
-        project.file(destinationDir)
+        projectOperations.file(destinationDir)
     }
 
     @OutputFile
@@ -86,7 +89,7 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
     }
 
     File getGemInstallDir() {
-        project.file(this.gemInstallDir)
+        projectOperations.file(this.gemInstallDir)
     }
 
     @TaskAction
@@ -98,27 +101,27 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
         String path = classpathFromConfiguration(jruby.jrubyConfiguration).join(File.pathSeparator)
         String gemDir = getGemInstallDir().absolutePath
         String bootstrapName = getBaseName()
+        String bootstrapTemplate = BOOTSTRAP_TEMPLATE
         logger.info("GenerateGradleRb - source: ${source}, destination: ${destination}, baseName: ${baseName}")
-        project.copy {
-            from(source) {
-                /* In the case of this plugin existing in a zip (i.e. the
-             * plugin jar) our `source` will be a ZipTree, so we only want
-             * to pull in the template itself
-             */
-                include "**/${GenerateGradleRb.BOOTSTRAP_TEMPLATE}"
-            }
-            into destination
-            fileMode = 0755
-            includeEmptyDirs = false
-            rename BOOTSTRAP_TEMPLATE, bootstrapName
-            // Flatten the file into the destination directory so we don't copy
-            // the file into: ${destination}/META-INF/gradle-plugins/gradle.rb
-            eachFile { FileCopyDetails details ->
-                details.relativePath = new RelativePath(true, [details.name] as String[])
-            }
+        projectOperations.copy { CopySpec cs ->
+            cs.with {
+                // In the case of this plugin existing in a zip (i.e. the plugin jar) our `source` will be a ZipTree,
+                // so we only want to pull in the template itself
+                from(source).include "**/${bootstrapTemplate}"
 
-            filter ReplaceTokens, beginToken: '%%', endToken: '%%',
-                tokens: [GEMFOLDER: gemDir, JRUBYEXEC_CLASSPATH: path]
+                into destination
+                fileMode = 0755
+                includeEmptyDirs = false
+                rename bootstrapTemplate, bootstrapName
+                // Flatten the file into the destination directory so we don't copy
+                // the file into: ${destination}/META-INF/gradle-plugins/gradle.rb
+                eachFile { FileCopyDetails details ->
+                    details.relativePath = new RelativePath(true, [details.name] as String[])
+                }
+
+                filter ReplaceTokens, beginToken: '%%', endToken: '%%',
+                    tokens: [GEMFOLDER: gemDir, JRUBYEXEC_CLASSPATH: path]
+            }
         }
     }
 
@@ -152,4 +155,5 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
     private Object destinationDir = project.projectDir
     private Object gemInstallDir
     private final JRubyPluginExtension jruby
+    private final ProjectOperations projectOperations
 }

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPlugin.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPlugin.groovy
@@ -32,7 +32,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 
-import static org.ysb33r.grolifant.api.TaskProvider.registerTask
+import static org.ysb33r.grolifant.api.v4.TaskProvider.registerTask
 
 /** Base plugin for JRuby.
  *
@@ -62,7 +62,7 @@ class JRubyPlugin implements Plugin<Project> {
         JRubyExecDelegate.addToProject(project, PROJECT_JRUBYEXEC)
 
         registerTask(
-            project,
+            project.tasks,
             'generateGradleRb',
             GenerateGradleRb
         ).configure(generateGradleRbConfiguration(project))

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPluginExtension.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPluginExtension.groovy
@@ -29,16 +29,27 @@ import com.github.jrubygradle.internal.JRubyPrepareUtils
 import groovy.transform.CompileStatic
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.logging.Logger
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
-import org.ysb33r.grolifant.api.AbstractCombinedProjectTaskExtension
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.TaskContainer
+import org.ysb33r.grolifant.api.core.ProjectOperations
+import org.ysb33r.grolifant.api.v4.AbstractCombinedProjectTaskExtension
+import org.ysb33r.grolifant.api.v4.TaskProvider
 
 import java.util.concurrent.Callable
 
-import static org.ysb33r.grolifant.api.StringUtils.stringize
+import static com.github.jrubygradle.JRubyPlugin.TASK_GROUP_NAME
+import static org.ysb33r.grolifant.api.v4.StringUtils.stringize
 
 /**
  * Class providing the jruby DSL extension to the Gradle build script.
@@ -61,6 +72,13 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
     JRubyPluginExtension(Project p) {
         super(p)
         this.jrubyVersion = DEFAULT_JRUBY_VERSION
+        this.repositories = p.repositories
+        this.dependencies = p.dependencies
+        this.configurations = p.configurations
+        this.providers = p.providers
+        this.logger = p.logger
+        this.tasks = p.tasks
+        this.projectOperations = ProjectOperations.create(p)
     }
 
     /** Task extension constructor
@@ -71,6 +89,13 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
      */
     JRubyPluginExtension(JRubyAwareTask t) {
         super(t, NAME)
+        this.repositories = t.project.repositories
+        this.dependencies = t.project.dependencies
+        this.configurations = t.project.configurations
+        this.providers = t.project.providers
+        this.logger = t.project.logger
+        this.tasks = t.project.tasks
+        this.projectOperations = ProjectOperations.create(t.project)
     }
 
     /** The default version of jruby that will be used.
@@ -87,7 +112,8 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
 
     /** Set a new JRuby version to use.
      *
-     * @param v New version to be used. Can be of anything that be be resolved by {@link StringUtils.stringize ( Object o )}
+     * @param v New version to be used. Can be of anything that be be resolved by
+     * {@link org.ysb33r.grolifant.api.v4.StringUtils#stringize ( Object o )}
      *
      * @since 2.0
      */
@@ -97,7 +123,8 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
 
     /** Set a new JRuby version to use.
      *
-     * @param v New version to be used. Can be of anything that be be resolved by {@link StringUtils.stringize ( Object o )}
+     * @param v New version to be used. Can be of anything that be be resolved by
+     * {@link org.ysb33r.grolifant.api.v4.StringUtils#stringize ( Object o )}
      *
      * @since 2.0
      */
@@ -153,8 +180,8 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
                         'It is recommended that you explicitly declare your repositories rather than rely on ' +
                         'this functionality.'
                 )
-                project.repositories.jcenter()
-                ((ExtensionAware) (project.repositories)).extensions.getByType(RepositoryHandlerExtension).gems()
+                repositories.jcenter()
+                ((ExtensionAware) (repositories)).extensions.getByType(RepositoryHandlerExtension).gems()
             } else {
                 deprecated(
                     'jruby.defaultRepositories are no longer switched on by default - you can safely remove ' +
@@ -207,7 +234,7 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
 
         List<Dependency> deps = [createDependency(jrubyCompleteDep)]
 
-        Configuration configuration = project.configurations.detachedConfiguration(
+        Configuration configuration = configurations.detachedConfiguration(
             deps.toArray() as Dependency[]
         )
 
@@ -221,16 +248,16 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
     /** Sets the GEM configuration.
      *
      * @param c Configuration instance, Character sequence as configuration name, or a {@code Provider<Configuration}.
-             */
+              */
     void setGemConfiguration(final Object c) {
         switch (c) {
             case Configuration:
-                this.gemConfiguration = project.provider({ -> c } as Callable<Configuration>)
+                this.gemConfiguration = providers.provider({ -> c } as Callable<Configuration>)
                 registerPrepareTask(((Configuration) c).name)
                 break
             case CharSequence:
                 this.gemConfiguration = project.provider(
-                    { -> project.configurations.getByName(c.toString()) } as Callable<Configuration>
+                    { -> configurations.getByName(c.toString()) } as Callable<Configuration>
                 )
                 registerPrepareTask(c.toString())
                 break
@@ -248,7 +275,7 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
     /** Declarative way of setting the GEM configuration.
      *
      * @param c Configuration instance, Character sequence as configuration name, or a {@code Provider<Configuration}.
-             */
+              */
     void gemConfiguration(final Object c) {
         setGemConfiguration(c)
     }
@@ -306,20 +333,43 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
     }
 
     private void deprecated(String msg) {
-        project.logger.info("Deprecated feature in ${NAME} extension. ${msg}")
+        logger.info("Deprecated feature in ${NAME} extension. ${msg}")
     }
 
     private Dependency createDependency(final String notation, final Closure configurator = null) {
         if (configurator) {
-            project.dependencies.create(notation, configurator)
+            dependencies.create(notation, configurator)
         } else {
-            project.dependencies.create(notation)
+            dependencies.create(notation)
         }
     }
 
     private void registerPrepareTask(final String configurationName) {
-        JRubyPrepareUtils.registerPrepareTask(project, configurationName)
-        this.gemPrepareTaskName = JRubyPrepareUtils.taskName(configurationName)
+        final String taskName = JRubyPrepareUtils.taskName(configurationName)
+        final String gemDir = JRubyPrepareUtils.gemRelativePath(configurationName)
+
+        try {
+            TaskProvider.taskByName(tasks, taskName)
+        } catch (UnknownTaskException e) {
+            TaskProvider<JRubyPrepare> prepare = TaskProvider.registerTask(tasks, taskName, JRubyPrepare)
+            ProjectOperations po = this.projectOperations
+            Action<JRubyPrepare> configurator = new Action<JRubyPrepare>() {
+                void execute(JRubyPrepare jp) {
+                    jp.with {
+                        group = TASK_GROUP_NAME
+                        description = "Prepare the gems/jars from the `${configurationName}` dependencies"
+                        dependencies(project.configurations.getByName(configurationName))
+                        outputDir =  { ->
+                            po.buildDirDescendant(gemDir)
+                        }
+                    }
+                }
+            }
+            prepare.configure(configurator as Action<? extends Task>)
+            prepare
+        }
+
+        this.gemPrepareTaskName = taskName//JRubyPrepareUtils.taskName(configurationName)
     }
 
     private static final String JRUBY_COMPLETE_DEPENDENCY = 'org.jruby:jruby-complete'
@@ -329,6 +379,12 @@ class JRubyPluginExtension extends AbstractCombinedProjectTaskExtension {
     private String gemPrepareTaskName
     private boolean taskResolutionStrategiesOnly = false
     private final List<Action<ResolutionStrategy>> resolutionsStrategies = []
-
+    private final ProjectOperations projectOperations
+    private final RepositoryHandler repositories
+    private final ConfigurationContainer configurations
+    private final DependencyHandler dependencies
+    private final ProviderFactory providers
+    private final TaskContainer tasks
+    private final Logger logger
     private boolean defaultRepositoriesCalled = false
 }

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPrepare.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyPrepare.groovy
@@ -42,6 +42,9 @@ class JRubyPrepare extends AbstractJRubyPrepare {
     JRubyPrepare() {
         super()
         this.jruby = extensions.create(JRubyPluginExtension.NAME, JRubyPluginExtension, this)
+        this.jrubyJarLocation = project.provider({ JRubyPluginExtension jrubyExt ->
+            JRubyExecUtils.jrubyJar(jrubyExt.jrubyConfiguration)
+        }.curry(this.jruby) as Callable<File>)
     }
 
     /** Location of {@code jruby-complete} JAR.
@@ -50,9 +53,7 @@ class JRubyPrepare extends AbstractJRubyPrepare {
      */
     @Override
     protected Provider<File> getJrubyJarLocation() {
-        project.provider({ JRubyPluginExtension jrubyExt ->
-            JRubyExecUtils.jrubyJar(jrubyExt.jrubyConfiguration)
-        }.curry(this.jruby) as Callable<File>)
+        this.jrubyJarLocation
     }
 
     /** Version of JRuby to be used.
@@ -67,5 +68,6 @@ class JRubyPrepare extends AbstractJRubyPrepare {
     }
 
     private final JRubyPluginExtension jruby
+    private final Provider<File> jrubyJarLocation
 }
 

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecDelegate.groovy
@@ -24,19 +24,24 @@
 package com.github.jrubygradle.internal
 
 import com.github.jrubygradle.JRubyPluginExtension
+import com.github.jrubygradle.JRubyPrepare
 import com.github.jrubygradle.api.core.JRubyExecSpec
+import groovy.transform.CompileStatic
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.tasks.TaskContainer
 import org.gradle.process.ExecResult
 import org.gradle.process.JavaExecSpec
-import org.ysb33r.grolifant.api.ClosureUtils
+import org.ysb33r.grolifant.api.core.ProjectOperations
+import org.ysb33r.grolifant.api.v4.ClosureUtils
 
 import static com.github.jrubygradle.JRubyExec.MAIN_CLASS
 import static com.github.jrubygradle.internal.JRubyExecUtils.buildArgs
 import static com.github.jrubygradle.internal.JRubyExecUtils.prepareJRubyEnvironment
 import static com.github.jrubygradle.internal.JRubyExecUtils.resolveScript
-import static org.ysb33r.grolifant.api.StringUtils.stringize
+import static org.ysb33r.grolifant.api.v4.StringUtils.stringize
 
 /** Delegate for running JRuby using {@code project.jrubyexec}.
  *
@@ -44,6 +49,7 @@ import static org.ysb33r.grolifant.api.StringUtils.stringize
  * @author R Tyler Croy
  *
  */
+@CompileStatic
 class JRubyExecDelegate {
 
     static void addToProject(final Project project, final String name) {
@@ -64,44 +70,54 @@ class JRubyExecDelegate {
     }
 
     ExecResult call(@DelegatesTo(JRubyExecSpec) Closure cfg) {
-        project.javaexec { JavaExecSpec javaExecSpec ->
-            ExecSpec execSpec = new ExecSpec(project, javaExecSpec)
+        projectOperations.javaexec { JavaExecSpec javaExecSpec ->
+            ExecSpec execSpec = new ExecSpec(projectOperations, javaExecSpec)
             ClosureUtils.configureItem(execSpec, cfg)
             finaliseJavaExecConfiguration(execSpec, javaExecSpec)
         }
     }
 
     ExecResult call(Action<JRubyExecSpec> cfg) {
-        project.javaexec { JavaExecSpec javaExecSpec ->
-            ExecSpec execSpec = new ExecSpec(project, javaExecSpec)
-            cfg.execute(spec)
+        projectOperations.javaexec { JavaExecSpec javaExecSpec ->
+            ExecSpec execSpec = new ExecSpec(projectOperations, javaExecSpec)
+            cfg.execute(execSpec)
             finaliseJavaExecConfiguration(execSpec, javaExecSpec)
         }
     }
 
     void finaliseJavaExecConfiguration(ExecSpec execSpec, JavaExecSpec javaExecSpec) {
-        JRubyPluginExtension jruby = project.extensions.getByType(JRubyPluginExtension)
+        JRubyPluginExtension jruby = extensions.getByType(JRubyPluginExtension)
         javaExecSpec.with {
             main = MAIN_CLASS
             classpath = jruby.jrubyConfiguration
-            args = buildArgs([], execSpec.jrubyArgs, execSpec.script, execSpec.scriptArgs)
+            args = buildArgs(
+                [],
+                execSpec.jrubyArgs as List<Object>,
+                execSpec.script,
+                execSpec.scriptArgs as List<Object>
+            )
+
             environment = prepareJRubyEnvironment(
                 environment,
                 execSpec.inheritRubyEnv,
-                project.tasks.getByName(jruby.gemPrepareTaskName).outputDir
+                ((JRubyPrepare)tasks.getByName(jruby.gemPrepareTaskName)).outputDir
             )
         }
     }
 
     private JRubyExecDelegate(Project project) {
-        this.project = project
+        this.projectOperations = ProjectOperations.find(project)
+        this.tasks = project.tasks
+        this.extensions = project.extensions
     }
 
-    private final Project project
+    private final ProjectOperations projectOperations
+    private final TaskContainer tasks
+    private final ExtensionContainer extensions
 
     private static class ExecSpec implements JRubyExecSpec {
-        ExecSpec(Project project, JavaExecSpec spec) {
-            this.project = project
+        ExecSpec(ProjectOperations projectOperations, JavaExecSpec spec) {
+            this.projectOperations = projectOperations
             this.javaExecSpec = spec
         }
 
@@ -139,12 +155,12 @@ class JRubyExecDelegate {
 
         @Override
         void script(Object scr) {
-            this.script = resolveScript(project, scr)
+            this.script = resolveScript(projectOperations, scr)
         }
 
         @Override
         void setScript(Object scr) {
-            this.script = resolveScript(project, scr)
+            this.script = resolveScript(projectOperations, scr)
         }
 
         @Override
@@ -195,6 +211,6 @@ class JRubyExecDelegate {
         private final List<String> jrubyArgs = []
         private final @Delegate
         JavaExecSpec javaExecSpec
-        private final Project project
+        private final ProjectOperations projectOperations
     }
 }

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecUtils.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyExecUtils.groovy
@@ -24,20 +24,17 @@
 package com.github.jrubygradle.internal
 
 import com.github.jrubygradle.JRubyPlugin
-import com.github.jrubygradle.JRubyPluginExtension
-import com.github.jrubygradle.api.gems.GemOverwriteAction
-import com.github.jrubygradle.api.gems.GemUtils
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.ysb33r.grolifant.api.OperatingSystem
-import org.ysb33r.grolifant.api.StringUtils
+import org.ysb33r.grolifant.api.core.ProjectOperations
+import org.ysb33r.grolifant.api.v4.StringUtils
 
 import java.util.regex.Matcher
 
-import static org.ysb33r.grolifant.api.StringUtils.stringize
+import static org.ysb33r.grolifant.api.v4.StringUtils.stringize
 
 /** Utilities for preparation or executing JRuby.
  *
@@ -120,17 +117,17 @@ class JRubyExecUtils {
 
     /** Resolves a script location object.
      *
-     * @paream project Project context for script.
+     * @paream project Project operations for script.
      * @param script Script to resolve.
      * @return Resolved script location. Will be {@code null} if {@code script == null},
      */
-    static File resolveScript(Project project, Object script) {
+    static File resolveScript(ProjectOperations projectOperations, Object script) {
         if (script) {
             File intermediate = script instanceof File ? (File) script : new File(stringize(script))
             if (intermediate.absolute) {
                 intermediate
             } else {
-                intermediate.parentFile ? project.file(script) : intermediate
+                intermediate.parentFile ? projectOperations.file(script) : intermediate
             }
         } else {
             null
@@ -217,58 +214,45 @@ class JRubyExecUtils {
         return path.absolutePath + File.pathSeparatorChar + originalPath
     }
 
-    /**
-     * Update the given configuration on the project with the appropriate versions
-     * of JRuby and supplemental dependencies to execute JRuby successfully
-     */
-    static void updateJRubyDependenciesForConfiguration(Project project, String configuration, String version) {
-        Configuration c = project.configurations.findByName(configuration)
-
-        /* Only define this dependency if we don't already have it */
-        if (!(c.dependencies.find { it.name == JRUBY_COMPLETE })) {
-            project.dependencies.add(configuration, "org.jruby:jruby-complete:${version}")
-        }
-    }
-
-    /**
-     * Prepare the Ruby and Java dependencies for the configured configuration
-     *
-     * This method will determine the appropriate dependency overwrite behavior
-     * from the Gradle invocation. In effect, if the --refresh-dependencies flag
-     * is used, already installed gems will be overwritten.
-     *
-     * @param project The associated Gradle project.
-     * @param gemWorkDir THe GEM unpack/working directory.
-     * @param jruby The associated JRuby project or task extension.
-     * @param gemConfiguration Configuration which contains GEMs for unpacking.
-     * @param overwrite Overwrite mode.
-     *
-     * @since 2.0
-     */
-    static void prepareDependencies(
-        Project project,
-        File gemWorkDir,
-        JRubyPluginExtension jruby,
-        Configuration gemConfiguration,
-        GemOverwriteAction overwrite
-    ) {
-        File gemDir = gemWorkDir.absoluteFile
-
-        gemDir.mkdirs()
-
-        GemUtils.extractGems(
-            project,
-            jruby.jrubyConfiguration,
-            gemConfiguration,
-            gemDir,
-            overwrite
-        )
-        GemUtils.setupJars(
-            gemConfiguration,
-            gemDir,
-            overwrite
-        )
-    }
+//    /**
+//     * Prepare the Ruby and Java dependencies for the configured configuration
+//     *
+//     * This method will determine the appropriate dependency overwrite behavior
+//     * from the Gradle invocation. In effect, if the --refresh-dependencies flag
+//     * is used, already installed gems will be overwritten.
+//     *
+//     * @param project The associated Gradle project.
+//     * @param gemWorkDir THe GEM unpack/working directory.
+//     * @param jruby The associated JRuby project or task extension.
+//     * @param gemConfiguration Configuration which contains GEMs for unpacking.
+//     * @param overwrite Overwrite mode.
+//     *
+//     * @since 2.0
+//     */
+//    static void prepareDependencies(
+//        Project project,
+//        File gemWorkDir,
+//        JRubyPluginExtension jruby,
+//        Configuration gemConfiguration,
+//        GemOverwriteAction overwrite
+//    ) {
+//        File gemDir = gemWorkDir.absoluteFile
+//
+//        gemDir.mkdirs()
+//
+//        GemUtils.extractGems(
+//            project,
+//            jruby.jrubyConfiguration,
+//            gemConfiguration,
+//            gemDir,
+//            overwrite
+//        )
+//        GemUtils.setupJars(
+//            gemConfiguration,
+//            gemDir,
+//            overwrite
+//        )
+//    }
 
     /** Prepare en environment which can be used to execute JRuby.
      *

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyPrepareUtils.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/internal/JRubyPrepareUtils.groovy
@@ -23,17 +23,10 @@
  */
 package com.github.jrubygradle.internal
 
-import com.github.jrubygradle.JRubyPrepare
 import groovy.transform.CompileStatic
-import org.gradle.api.Action
-import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.UnknownTaskException
-import org.ysb33r.grolifant.api.TaskProvider
 
 import static com.github.jrubygradle.JRubyPlugin.DEFAULT_CONFIGURATION
 import static com.github.jrubygradle.JRubyPlugin.DEFAULT_PREPARE_TASK
-import static com.github.jrubygradle.JRubyPlugin.TASK_GROUP_NAME
 
 /** Utilities to deal with JRubPrepare tasks
  *
@@ -56,44 +49,11 @@ class JRubyPrepareUtils {
 
     /** GEM working (unpack) relative path by convention.
      *
-     * @param configurationName  Name of a GEM configuration.
+     * @param configurationName Name of a GEM configuration.
      * @return Associated relative path to project directory.
      */
     static String gemRelativePath(String configurationName) {
         configurationName == DEFAULT_CONFIGURATION ? '.gems' :
             ".gems-${configurationName}"
-    }
-
-    /** Registers (or creates) a JRUbyPrepare tasks based upon a configuration name
-     *
-     * @param project Associated project
-     * @param configurationName
-     * @return Grolifant {@code TaskProvider}.
-     */
-    static TaskProvider<JRubyPrepare> registerPrepareTask(
-        final Project project,
-        final String configurationName
-    ) {
-        final String taskName = taskName(configurationName)
-        final String gemDir = gemRelativePath(configurationName)
-
-        try {
-            TaskProvider.taskByName(project, taskName)
-        } catch (UnknownTaskException e) {
-            TaskProvider<JRubyPrepare> prepare = TaskProvider.registerTask(project, taskName, JRubyPrepare)
-            Action<JRubyPrepare> configurator = new Action<JRubyPrepare>() {
-                void execute(JRubyPrepare jp) {
-                    jp.with {
-                        group = TASK_GROUP_NAME
-                        description = "Prepare the gems/jars from the `${configurationName}` dependencies"
-                        dependencies(project.configurations.getByName(configurationName))
-                        outputDir { "${project.buildDir}/${gemDir}" }
-                    }
-                }
-            }
-            prepare.configure(configurator as Action<? extends Task>)
-            prepare
-        }
-
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ allprojects {
 }
 
 subprojects {
-
     apply plugin: 'maven'
 
     repositories {
@@ -55,8 +54,8 @@ subprojects {
         dependencies {
             compile localGroovy()
             compile gradleApi()
-            compile 'org.ysb33r.gradle:grolifant:0.12'
-            gradleTestRuntime 'org.ysb33r.gradle:grolifant:0.12'
+            compile "org.ysb33r.gradle:grolifant50:${grolifantVersion}"
+            gradleTestRuntime "org.ysb33r.gradle:grolifant50:${grolifantVersion}"
         }
 
         codenarc {
@@ -79,9 +78,9 @@ subprojects {
         gradleTest {
             // https://github.com/jruby-gradle/jruby-gradle-plugin/issues/346
             if (JavaVersion.current().java11) {
-                versions '5.0', '5.4.1', '6.0.1'
+                versions '5.0', '5.4.1', '6.0.1', '6.7'
             } else {
-                versions '4.10.2', '5.3.1', '6.0.1'
+                versions '4.10.2', '5.3.1', '6.0.1', '6.7'
 
                 if(project.name == 'jruby-gradle-core-plugin' ) {
                     versions '4.3'

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/JRubyCorePlugin.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/JRubyCorePlugin.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.ExtensionAware
+import org.ysb33r.grolifant.api.core.ProjectOperations
 
 /** Provides only a repository handler extensiosn for looking up rubygem
  * metadata.
@@ -42,6 +43,7 @@ import org.gradle.api.plugins.ExtensionAware
 class JRubyCorePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
+        ProjectOperations.maybeCreateExtension(project)
         GemResolverStrategy gemGroups = project.extensions.create(GemResolverStrategy.NAME, GemResolverStrategy)
 
         ((ExtensionAware) project.repositories).extensions.create(

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/gems/GemResolverStrategy.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/gems/GemResolverStrategy.groovy
@@ -65,7 +65,7 @@ class GemResolverStrategy {
      * @param configs Configurations to be excluded
      */
     void excludeConfigurations(Configuration... configs) {
-        this.excludedConfigurations.addAll(configs*.name)
+        this.excludedConfigurations.addAll(configs*.name as Iterable<String>)
     }
 
     /** Exclude a configuration from being resolved using the GEM
@@ -132,7 +132,7 @@ class GemResolverStrategy {
         }
     }
 
-    private final Set<Matcher> excludedModules = [].toSet()
-    private final Set<String> excludedConfigurations = [].toSet()
+    private final Set<Matcher> excludedModules = [].toSet() as Set<Matcher>
+    private final Set<String> excludedConfigurations = [].toSet() as Set<String>
     private final Set<String> groups = [RepositoryHandlerExtension.DEFAULT_GROUP_NAME].toSet()
 }

--- a/core-plugin/src/test/groovy/com/github/jrubygradle/api/gems/GemUtilsSpec.groovy
+++ b/core-plugin/src/test/groovy/com/github/jrubygradle/api/gems/GemUtilsSpec.groovy
@@ -28,6 +28,7 @@ import com.github.jrubygradle.api.gems.GemUtils
 import org.gradle.api.Project
 import org.gradle.api.file.DuplicateFileCopyingException
 import org.gradle.testfixtures.ProjectBuilder
+import org.ysb33r.grolifant.api.core.ProjectOperations
 import spock.lang.Specification
 
 import static com.github.jrubygradle.api.gems.GemOverwriteAction.FAIL
@@ -46,6 +47,7 @@ class GemUtilsSpec extends Specification {
 
     void setup() {
         project = ProjectBuilder.builder().build()
+        ProjectOperations.maybeCreateExtension(project)
         src = project.file('src')
         dest = project.file('dest')
         fakeGem = new File(src, 'gems/mygem-1.0')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.0.0
+version=2.1.0-alpha.1
 group=com.github.jruby-gradle
 copyrightYear=2014-2020
 
@@ -14,6 +14,7 @@ releaseBuild=false
 targetCompatibility=1.8
 sourceCompatibility=1.8
 
+grolifantVersion=1.0.0-alpha.1
 jrubyVersion=9.2.9.0
 jettyVersion=9.2.12.v20150709
 bcprovVersion=1.46

--- a/jar-plugin/src/integTest/groovy/com/github/jrubygradle/jar/JRubyJarTestKitSpec.groovy
+++ b/jar-plugin/src/integTest/groovy/com/github/jrubygradle/jar/JRubyJarTestKitSpec.groovy
@@ -227,7 +227,7 @@ class JRubyJarTestKitSpec extends IntegrationSpecification {
 
     private BuildResult build(String taskName, String... additionalTasks) {
         writeBuildFile()
-        List<String> tasks = ['-i', taskName]
+        List<String> tasks = ['-i', '-s', taskName]
         tasks.addAll(additionalTasks)
         gradleRunner(tasks).build()
     }


### PR DESCRIPTION
- Use the new 1.0.0-alpha.1 Grolifant release that has configuration-cache
  safety built-in.
- Check that no usage of `Project` object will be done after configuration
  phase has ended.
- Maintain compatibility down to Gradle 4.3.