### PR TITLE
Fix task property annotation problems

### DIFF
--- a/base-plugin/src/main/groovy/com/github/jrubygradle/GenerateGradleRb.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/GenerateGradleRb.groovy
@@ -33,6 +33,7 @@ import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.core.ProjectOperations
@@ -74,6 +75,7 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
         this.gemInstallDir = dir
     }
 
+    @Internal
     File getDestinationDir() {
         projectOperations.file(destinationDir)
     }
@@ -88,8 +90,14 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
         StringUtils.stringize(baseName)
     }
 
+    @Internal
     File getGemInstallDir() {
         projectOperations.file(this.gemInstallDir)
+    }
+
+    @Input
+    protected String getGemInstallDirPath() {
+        getGemInstallDir().absolutePath
     }
 
     @TaskAction
@@ -99,7 +107,7 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
         Object source = getSourceFromResource()
         File destination = destinationFile().parentFile
         String path = classpathFromConfiguration(jruby.jrubyConfiguration).join(File.pathSeparator)
-        String gemDir = getGemInstallDir().absolutePath
+        String gemDir = getGemInstallDirPath()
         String bootstrapName = getBaseName()
         String bootstrapTemplate = BOOTSTRAP_TEMPLATE
         logger.info("GenerateGradleRb - source: ${source}, destination: ${destination}, baseName: ${baseName}")

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
@@ -29,10 +29,15 @@ import com.github.jrubygradle.internal.JRubyExecUtils
 import groovy.transform.CompileStatic
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.model.ReplacedBy
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.process.JavaExecSpec
 import org.gradle.util.GradleVersion
@@ -100,7 +105,8 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
      * @return The path to the script (or {@code null} if not set)
      */
     @Optional
-    @Input
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
     File getScript() {
         resolveScript(projectOperations, this.script)
     }
@@ -185,6 +191,7 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
      *
      * @return Provider of GEM working directory.
      */
+    @LocalState
     Provider<File> getGemWorkDir() {
         this.gemWorkDir
     }
@@ -196,6 +203,7 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
      *
      */
     @Deprecated
+    @ReplacedBy('jruby.jrubyVersion')
     String getJrubyVersion() {
         deprecated('Use jruby.getJrubyVersion() rather getJrubyVersion()')
         jruby.jrubyVersion

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,11 @@ subprojects {
             ideReport.enabled = true
             ideReport.destination = file( "${project.codenarc.reportsDir}/${reportName}.ide.txt")
         }
+
+        tasks.withType(ValidateTaskProperties) { validateTaskProperties ->
+            validateTaskProperties.failOnWarning = true
+            validateTaskProperties.enableStricterValidation = true
+        }
     }
 
     idea {

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/AbstractJRubyPrepare.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/AbstractJRubyPrepare.groovy
@@ -34,12 +34,14 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.core.ProjectOperations
 
 import static com.github.jrubygradle.api.gems.GemOverwriteAction.SKIP
 import static com.github.jrubygradle.api.gems.GemUtils.extractGems
 import static com.github.jrubygradle.api.gems.GemUtils.setupJars
+import static org.gradle.api.tasks.PathSensitivity.ABSOLUTE
 
 /** Abstract base class for building custom tasks for preparing GEMs.
  *
@@ -86,10 +88,25 @@ abstract class AbstractJRubyPrepare extends DefaultTask implements JRubyAwareTas
     /** All GEMs that have been supplied as dependencies.
      *
      * @return Collection of GEMs.
+     *
+     * @see #getGemsAsFileCollection()
+     * @deprecated Use {@link #getGemsAsFileCollection()} instead.
+     */
+    @Deprecated
+    FileCollection gemsAsFileCollection() {
+        gemsAsFileCollection
+    }
+
+    /** All GEMs that have been supplied as dependencies.
+     *
+     * @return Collection of GEMs.
+     *
+     * @since 2.1.0
      */
     @InputFiles
-    FileCollection gemsAsFileCollection() {
-        return GemUtils.getGems(projectOperations.files(this.dependencies))
+    @PathSensitive(ABSOLUTE)
+    FileCollection getGemsAsFileCollection() {
+        GemUtils.getGems(projectOperations.files(this.dependencies))
     }
 
     @Internal
@@ -99,7 +116,6 @@ abstract class AbstractJRubyPrepare extends DefaultTask implements JRubyAwareTas
      *
      * @param f One or more of file, directory, configuration or list of gems.
      */
-    @Optional
     void dependencies(Object... f) {
         this.dependencies.addAll(f.toList())
     }
@@ -110,6 +126,7 @@ abstract class AbstractJRubyPrepare extends DefaultTask implements JRubyAwareTas
      *
      * @since 2.1.0
      */
+    @Internal
     protected ProjectOperations getProjectOperations() {
         this.projectOperations
     }


### PR DESCRIPTION
This PR fixes some validation problems with tasks in the plugin that will cause any build using the plugin to fail with Gradle 7.0. It also enables strict validation during the build, so any new validation problems introduced will make the build fail.

The particular problems fixed by this PR are:

```text
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':jruby-gradle-core-plugin:validateTaskProperties'.
> Task property validation failed. See https://docs.gradle.org/5.4.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Task type 'com.github.jrubygradle.api.core.AbstractJRubyPrepare': property 'projectOperations' is not annotated with an input or output annotation.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':jruby-gradle-plugin:validateTaskProperties'.
> Task property validation failed. See https://docs.gradle.org/5.4.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Task type 'com.github.jrubygradle.GenerateGradleRb': property 'destinationDir' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.GenerateGradleRb': property 'gemInstallDir' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.JRubyExec': property 'gemWorkDir' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.JRubyExec': property 'jrubyVersion' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.JRubyExec': property 'script' has @Input annotation used on property of type java.io.File.
   > Warning: Task type 'com.github.jrubygradle.JRubyPrepare': property 'projectOperations' is not annotated with an input or output annotation.
```