### PR TITLE
Fix task property annotation problems for 2.0

### DIFF
--- a/base-plugin/src/main/groovy/com/github/jrubygradle/GenerateGradleRb.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/GenerateGradleRb.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.StringUtils
@@ -71,6 +72,7 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
         this.gemInstallDir = dir
     }
 
+    @Internal
     File getDestinationDir() {
         project.file(destinationDir)
     }
@@ -85,8 +87,14 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
         StringUtils.stringize(baseName)
     }
 
+    @Internal
     File getGemInstallDir() {
         project.file(this.gemInstallDir)
+    }
+
+    @Input
+    protected String getGemInstallDirPath() {
+        getGemInstallDir().absolutePath
     }
 
     @TaskAction
@@ -96,7 +104,7 @@ class GenerateGradleRb extends DefaultTask implements JRubyAwareTask {
         Object source = getSourceFromResource()
         File destination = destinationFile().parentFile
         String path = classpathFromConfiguration(jruby.jrubyConfiguration).join(File.pathSeparator)
-        String gemDir = getGemInstallDir().absolutePath
+        String gemDir = getGemInstallDirPath()
         String bootstrapName = getBaseName()
         logger.info("GenerateGradleRb - source: ${source}, destination: ${destination}, baseName: ${baseName}")
         project.copy {

--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
@@ -29,9 +29,12 @@ import com.github.jrubygradle.internal.JRubyExecUtils
 import groovy.transform.CompileStatic
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.model.ReplacedBy
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.Optional
 import org.gradle.process.JavaExecSpec
 import org.gradle.util.GradleVersion
@@ -89,8 +92,7 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
     /** Script to execute.
      * @return The path to the script (or {@code null} if not set)
      */
-    @Optional
-    @Input
+    @Internal
     File getScript() {
         resolveScript(project, this.script)
     }
@@ -175,6 +177,7 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
      *
      * @return Provider of GEM working directory.
      */
+    @LocalState
     Provider<File> getGemWorkDir() {
         Callable<File> resolveGemWorkDir = { JRubyPluginExtension jpe ->
             ((JRubyPrepare) project.tasks.getByName(jpe.gemPrepareTaskName)).outputDir
@@ -190,6 +193,7 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
      *
      */
     @Deprecated
+    @ReplacedBy('jruby.jrubyVersion')
     String getJrubyVersion() {
         deprecated('Use jruby.getJrubyVersion() rather getJrubyVersion()')
         jruby.jrubyVersion
@@ -304,6 +308,15 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
     @Override
     JavaExecSpec args(Iterable<?> args) {
         throw notAllowed(USE_JVM_ARGS)
+    }
+
+    /** Capture the path of the script as an input.
+     * @return the path of the script to execute.
+     */
+    @Optional
+    @Input
+    protected String getScriptPath() {
+        getScript()?.path
     }
 
     private static UnsupportedOperationException notAllowed(final String msg) {

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,11 @@ subprojects {
             ideReport.enabled = true
             ideReport.destination = file( "${project.codenarc.reportsDir}/${reportName}.ide.txt")
         }
+
+        tasks.withType(ValidateTaskProperties) { validateTaskProperties ->
+            validateTaskProperties.failOnWarning = true
+            validateTaskProperties.enableStricterValidation = true
+        }
     }
 
     idea {

--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/AbstractJRubyPrepare.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/core/AbstractJRubyPrepare.groovy
@@ -34,11 +34,13 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.TaskAction
 
 import static com.github.jrubygradle.api.gems.GemOverwriteAction.SKIP
 import static com.github.jrubygradle.api.gems.GemUtils.extractGems
 import static com.github.jrubygradle.api.gems.GemUtils.setupJars
+import static org.gradle.api.tasks.PathSensitivity.ABSOLUTE
 
 /** Abstract base class for building custom tasks for preparing GEMs.
  *
@@ -81,9 +83,24 @@ abstract class AbstractJRubyPrepare extends DefaultTask implements JRubyAwareTas
     /** All GEMs that have been supplied as dependencies.
      *
      * @return Collection of GEMs.
+     *
+     * @see #getGemsAsFileCollection()
+     * @deprecated Use {@link #getGemsAsFileCollection()} instead.
+     */
+    @Deprecated
+    FileCollection gemsAsFileCollection() {
+        gemsAsFileCollection
+    }
+
+    /** All GEMs that have been supplied as dependencies.
+     *
+     * @return Collection of GEMs.
+     *
+     * @since 2.1.0
      */
     @InputFiles
-    FileCollection gemsAsFileCollection() {
+    @PathSensitive(ABSOLUTE)
+    FileCollection getGemsAsFileCollection() {
         return GemUtils.getGems(project.files(this.dependencies))
     }
 
@@ -94,7 +111,6 @@ abstract class AbstractJRubyPrepare extends DefaultTask implements JRubyAwareTas
      *
      * @param f One or more of file, directory, configuration or list of gems.
      */
-    @Optional
     void dependencies(Object... f) {
         this.dependencies.addAll(f.toList())
     }
@@ -121,7 +137,7 @@ abstract class AbstractJRubyPrepare extends DefaultTask implements JRubyAwareTas
     void exec() {
         File out = getOutputDir()
         File jrubyJar = jrubyJarLocation.get()
-        extractGems(project, jrubyJar, gemsAsFileCollection(), out, SKIP)
+        extractGems(project, jrubyJar, gemsAsFileCollection, out, SKIP)
 
         dependencies.findAll {
             it instanceof Configuration


### PR DESCRIPTION
Backport of https://github.com/jruby-gradle/jruby-gradle-plugin/pull/418.

This PR fixes some validation problems with tasks in the plugin that will cause any build using the plugin to fail with Gradle 7.0. It also enables strict validation during the build, so any new validation problems introduced will make the build fail.

The particular problems fixed by this PR are:

```text
* What went wrong:
Execution failed for task ':jruby-gradle-plugin:validateTaskProperties'.
> Task property validation failed. See https://docs.gradle.org/5.4.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Task type 'com.github.jrubygradle.GenerateGradleRb': property 'destinationDir' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.GenerateGradleRb': property 'gemInstallDir' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.JRubyExec': property 'gemWorkDir' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.JRubyExec': property 'jrubyVersion' is not annotated with an input or output annotation.
   > Warning: Task type 'com.github.jrubygradle.JRubyExec': property 'script' has @Input annotation used on property of type java.io.File.
```