### PR TITLE
Use new `mainClass` property instead of `main`

### DIFF
--- a/core-plugin/src/main/groovy/com/github/jrubygradle/api/gems/GemUtils.groovy
+++ b/core-plugin/src/main/groovy/com/github/jrubygradle/api/gems/GemUtils.groovy
@@ -187,7 +187,7 @@ class GemUtils {
                         JARS_SKIP: true,
                         GEM_HOME: destDir.absolutePath,
                         GEM_PATH: destDir.absolutePath
-                    main = JRUBY_MAINCLASS
+                    mainClass = JRUBY_MAINCLASS
                     classpath jRubyClasspath
                     args '-S', GEM, 'install'
 


### PR DESCRIPTION
This should remove the deprecation warning and fix #427 .