### PR TITLE
Upgrade workflow to `gradle-build-action@v2`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,27 +8,14 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      # Cache
-      - name: Cache .gradle/caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-cache-
-      - name: Cache .gradle/wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-wrapper-
       # Licensing
       - name: Licensing
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain -S license
       # Coding style
       - name: Coding style
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain -i codenarcMain codenarcTest codenarcIntTest
   build-windows:
@@ -41,44 +28,26 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      # Cache
-      - name: Cache .gradle/caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-cache-
-      - name: Cache .gradle/wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-wrapper-
       # Build
       - name: Build
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain --warning-mode=all clean assemble
       # Test
       - name: UnitTest
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain --warning-mode=all --no-parallel test
       # Test
       - name: IntegrationTest
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain --warning-mode=all --no-parallel intTest
       # Test
       - name: CompatibilityTest
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain --warning-mode=all --no-parallel gradleTest
-      # Stop gradlew to avoid locking issues
-      - name: Cleanup
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: --stop
       - name: Store reports
         uses: actions/upload-artifact@v2
         if: always()
@@ -97,37 +66,24 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    # Cache
-    - name: Cache .gradle/caches
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-cache-
-    - name: Cache .gradle/wrapper
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-wrapper-
     # Build
     - name: Build
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -S --console=plain --no-build-cache assemble validateTaskProperties
       # Unit tests
     - name: Unit tests
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -s --console=plain --no-build-cache test
     # Integration tests
     - name: Integration tests
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -s --console=plain --no-build-cache intTest
     # Gradle tests
     - name: Compatibility tests
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -s --console=plain --no-build-cache gradleTest
     - name: Store reports
@@ -150,27 +106,15 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - name: Cache .gradle/caches
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-cache-
-    - name: Cache .gradle/wrapper
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-wrapper-
     - name: Publish to Gradle Portal
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       env:
         PUBLISH_KEY: ${{ secrets.PUBLISH_KEY }}
         PUBLISH_SECRET: ${{ secrets.PUBLISH_SECRET }}
       with:
         arguments: -i --console=plain --no-build-cache assemble publishPlugins -Dgradle.publish.key=$PUBLISH_KEY -Dgradle.publish.secret=$PUBLISH_SECRET
     - name: Publish documentation
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       env:
         GH_PAGES_PUSH_USER: ${{ secrets.GH_PAGES_PUSH_USER }}
         GH_PAGES_PUSH_TOKEN: ${{ secrets.GH_PAGES_PUSH_TOKEN }}


### PR DESCRIPTION
Upgrades the GitHub actions workflow to the latest v2 version (presently v2.0-beta.7).

This new action:
- has simpler configuration
- does a better job of caching the Gradle User Home state between build invocations
- automatically adds annotations with build scan URLs for all gradle invocations.

Due to the second item, I've removed the separate use of `actions/cache` for caching.
I'd be very interested to know if there is any regression in performance with this change.