### PR TITLE
Add the configuration's name as an input property

### DIFF
--- a/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
+++ b/base-plugin/src/main/groovy/com/github/jrubygradle/JRubyExec.groovy
@@ -89,7 +89,7 @@ class JRubyExec extends JavaExec implements JRubyAwareTask, JRubyExecSpec {
         }.curry(this.jruby)
 
         inputs.property 'gemConfiguration', { JRubyPluginExtension jruby ->
-            jruby.gemConfiguration
+            jruby.gemConfiguration.name
         }.curry(this.jruby)
 
         if (GradleVersion.current() >= GradleVersion.version('4.10')) {


### PR DESCRIPTION
Instead of the configuration itself as that doesn't work on Gradle 8

Fixes #448 

cc @donv, @UweKubosch, @rtyler, @ysb33r 